### PR TITLE
split pid types

### DIFF
--- a/invenio_records_resources/services/record.py
+++ b/invenio_records_resources/services/record.py
@@ -37,7 +37,8 @@ class RecordServiceConfig(ServiceConfig):
     record_cls = Record
     resolver_cls = Resolver
     resolver_obj_type = "rec"
-    pid_type = "recid"  # PID type for resolver, minter, and fetcher
+    resolver_pid_type = "recid"  # PID type for resolver and fetch
+    minter_pid_type = "recid_v2"
     indexer_cls = RecordIndexer
     search_cls = RecordsSearch
     search_engine_cls = SearchEngine
@@ -60,8 +61,8 @@ class RecordService(Service):
     def resolver(self):
         """Factory for creating a resolver instance."""
         return self.config.resolver_cls(
-            pid_type=self.config.pid_type,
-            getter=self.config.record_cls.get_record,
+            pid_type=self.config.resolver_pid_type,
+            getter=self.config.record_cls.get_record
         )
 
     def resolve(self, id_):
@@ -70,11 +71,11 @@ class RecordService(Service):
 
     def minter(self):
         """Returns the minter function."""
-        return current_pidstore.minters[self.config.pid_type]
+        return current_pidstore.minters[self.config.minter_pid_type]
 
     def fetcher(self):
         """Returns the fetcher function."""
-        return current_pidstore.fetchers[self.config.pid_type]
+        return current_pidstore.fetchers[self.config.resolver_pid_type]
 
     def indexer(self):
         """Factory for creating an indexer instance."""

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -49,10 +49,10 @@ def app_with_custom_minter(app):
         data['recid'] = provider.pid.pid_value
         return provider.pid
 
-    current_pidstore.minters['recid'] = custom_minter
+    current_pidstore.minters['recid_v2'] = custom_minter
     yield app
 
-    current_pidstore.minters['recid'] = recid_minter
+    current_pidstore.minters['recid_v2'] = recid_minter
 
 
 def test_create_read_record(client, input_record):


### PR DESCRIPTION
requires #36

There is a need to encapsulate pids management (resolver, minter, fetcher, types, even versioning). It will be addressed in a different PR.