### PR TITLE
SHOW ONLY: DO NOT MERGE

### DIFF
--- a/invenio_records_resources/record/__init__.py
+++ b/invenio_records_resources/record/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record module."""
+
+from .pid_manager import PIDManager
+from .pid_record import PIDRecord
+
+
+__all__ = ("PIDManager", "PIDRecord")

--- a/invenio_records_resources/record/pid_manager.py
+++ b/invenio_records_resources/record/pid_manager.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Persistent identifier manager."""
+
+from invenio_pidstore import current_pidstore
+from invenio_pidstore.models import PIDStatus
+from invenio_pidstore.resolver import Resolver
+from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
+from invenio_records.api import Record
+
+class PIDManager:
+
+    def __init__(self, resolver_cls=Resolver, resolver_obj_getter=Record.get_record,
+                 resolver_pid_type="recid", minter_pid_type="recid_v2",
+                 provider_cls=RecordIdProviderV2, object_type='rec',
+                 registered_only=True):
+
+        self.resolver = resolver_cls(
+            pid_type=resolver_pid_type,
+            getter=resolver_obj_getter,
+            registered_only=registered_only
+        )
+        self.provider_cls = provider_cls
+        self.object_type=object_type
+
+    @property
+    def minter():
+        # Need to be lazy loaded to be on an app ctx
+        return current_pidstore.minters[minter_pid_type]
+
+    @property
+    def fetcher():
+        return current_pidstore.fetchers[resolver_pid_type]
+
+    def create(self, record, status=PIDStatus.REGISTERED,
+               options=None, **kwargs):
+        self.provider_cls.default_status_with_obj = status
+
+        return self.provider_cls.create(
+            self.object_type, record.id, options, **kwargs
+        ).pid
+
+    def get(self, value):
+        return fetcher.get(value)
+
+    def resolve(self, id_):
+        return self.resolver.resolve(id_)

--- a/invenio_records_resources/record/pid_record.py
+++ b/invenio_records_resources/record/pid_record.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record module."""
+
+from invenio_records.api import Record
+from invenio_db import db
+
+from ..resource_units import IdentifiedRecord
+from ..schemas import MetadataSchemaJSONV1
+from ..services.data_validator import MarshmallowDataValidator
+from .pid_manager import PIDManager
+
+
+class PIDRecord(Record):
+    """Persistent identifier manager."""
+
+    # Config cls
+    schema_cls=MetadataSchemaJSONV1
+    resource_unit_cls = IdentifiedRecord
+
+    # Instances
+    data_validator = MarshmallowDataValidator(schema=schema_cls)
+    pid_manager = PIDManager()
+
+    @classmethod
+    def create(cls, data):
+        """Registers a record.
+        - Validates the record, based on the `scheme`. A Marshmallow
+          independent validator can be used by setting the `data_validator`
+          property.
+        - Creates the record
+        - Creates and associates (mint) the PID to the record UUID. The PID is
+          `REGISTERED` by default.
+
+        :return: a resource unit instance with the pid and the record.
+        """
+        cls.data_validator.validate(data)
+        record = super().create(data)  # Create record in DB
+        pid = cls.pid_manager.create(record)
+        db.session.commit()  # Persist DB
+
+        return cls.resource_unit_cls(pid=pid, record=record)
+
+    @classmethod
+    def register(cls, pid):
+        self.pid.register()
+
+    @classmethod
+    def get_from_id(cls, id_):
+        return cls.resource_unit_cls(*cls.pid_manager.resolve(id_))
+
+
+


### PR DESCRIPTION
**ONLY `test_create_read_record` IS FULLY FUNCTIONAL**

**Idea:**

- An enriched `Record` class that returns always a `unit`. In this case PID + Record. 
- The pid manager will encapsulate anything that has to do with: resolver, fetcher, minters and providers.


**Problems:**
- Some attributes like `default_status` and `default_status_with_obj` are class attributes on `Providers`, which does not make it easy to set on demand.
- Many of the operations (e.g. pid creation) could be useful to do separately. However accesing Provider + Minter, defeats the purpose of the Minter. --> Up to what extent do we want to not change PIDStore?
- Data validator module and classes si part of the `service` atm. However, it is imported in the `pid_record`. Solution: move to the `record` module, which would make sense. Do the same with `schemas`.

**Alternative:**
- An instantiable class with `pid` and `record` attributes.
- Problems most likely would persist on this approach.


