### PR TITLE
fix: test search correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,14 @@ services:
 
 env:
   global:
+    - ES6_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.2.tar.gz"
     - ES7_DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.3.0-linux-x86_64.tar.gz"
     - ES_HOST=127.0.0.1
     - SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
   matrix:
     # - REQUIREMENTS=lowest ES_URL=$ES7_DOWNLOAD_URL
     # - REQUIREMENTS=release ES_URL=$ES7_DOWNLOAD_URL
+    - REQUIREMENTS=devel ES_URL=$ES6_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch6
     - REQUIREMENTS=devel ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -38,7 +39,7 @@ env:
     # - REQUIREMENTS=lowest ES_URL=$ES7_DOWNLOAD_URL
     # - REQUIREMENTS=release ES_URL=$ES7_DOWNLOAD_URL
     - REQUIREMENTS=release ES_URL=$ES6_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch6
-    - REQUIREMENTS=release ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7 DEPLOY=true
+    - REQUIREMENTS=release ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7
     - REQUIREMENTS=devel ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   fast_finish: true
   allow_failures:
     # To allow failures, you need to specify the full environment
-    - env: REQUIREMENTS=devel
+    - env: REQUIREMENTS=devel ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7
 
 cache:
   - pip
@@ -37,7 +37,8 @@ env:
   matrix:
     # - REQUIREMENTS=lowest ES_URL=$ES7_DOWNLOAD_URL
     # - REQUIREMENTS=release ES_URL=$ES7_DOWNLOAD_URL
-    - REQUIREMENTS=devel ES_URL=$ES6_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch6
+    - REQUIREMENTS=release ES_URL=$ES6_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch6
+    - REQUIREMENTS=release ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7 DEPLOY=true
     - REQUIREMENTS=devel ES_URL=$ES7_DOWNLOAD_URL EXTRAS=all,postgresql,elasticsearch7
 
 python:
@@ -58,7 +59,8 @@ before_install:
 
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
-  - "travis_retry pip install -e .[all]"
+  - "travis_retry pip install -e .[$EXTRAS]"
+  - "pip freeze"
 
 script:
   - "./run-tests.sh"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,6 +30,7 @@ recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
 recursive-include tests *.py
+recursive-include tests/mock_module *.json
 recursive-include invenio_records_resources *.html
 recursive-include invenio_records_resources *.py
 recursive-include invenio_records_resources/translations *.po *.pot *.mo

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -10,5 +10,3 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
-
--e git+https://github.com/inveniosoftware/flask-resources.git#egg=flask-resources

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern Universtiy.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -45,9 +46,12 @@ extras_require = {
     "tests": tests_require,
 }
 
-extras_require["all"] = []
-for reqs in extras_require.values():
-    extras_require["all"].extend(reqs)
+all_requires = []
+for key, reqs in extras_require.items():
+    if key in {"elasticsearch6", "elasticsearch7"}:
+        continue
+    all_requires.extend(reqs)
+extras_require["all"] = all_requires
 
 setup_requires = [
     "Babel>=1.3",

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,11 @@ install_requires = [
     "invenio-indexer>=1.1.1",
     "invenio-records>=1.3.2",
     "invenio-rest>=1.2.1",
-    "flask-resources>=0.2.0,<1.0.0",
+    "flask-resources>=0.2.1,<1.0.0",
     # Service
     "invenio-accounts>=1.3.0",
     "invenio-files-rest>=1.2.0",
-    "invenio-records-permissions>=0.8.0",
+    "invenio-records-permissions>=0.9.0,<1.0.0",
     "xmltodict~=0.12.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ class TestSearch(RecordsSearch):
     class Meta:
         """Test configuration."""
 
-        index = 'invenio-records-resources'
+        index = "invenio-records-resources"
 
 
 @pytest.fixture(scope='module')
@@ -136,9 +136,9 @@ class AnyUserPermissionPolicy(RecordPermissionPolicy):
 
 
 @pytest.fixture(scope="module")
-def app(app):
+def base_app(base_app):
     """Application factory fixture."""
-    search = app.extensions["invenio-search"]
+    search = base_app.extensions["invenio-search"]
     search.register_mappings(TestSearch.Meta.index, 'mock_module.mappings')
 
     RecordServiceConfig.permission_policy_cls = AnyUserPermissionPolicy
@@ -148,7 +148,7 @@ def app(app):
     custom_bp = (
         RecordResource(service=RecordService()).as_blueprint("base_resource")
     )
-    app.register_blueprint(custom_bp)
-    app.register_error_handler(HTTPException, handle_http_exception)
-    with app.app_context():
-        yield app
+    base_app.register_blueprint(custom_bp)
+    base_app.register_error_handler(HTTPException, handle_http_exception)
+
+    yield base_app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more

--- a/tests/mock_module/__init__.py
+++ b/tests/mock_module/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Mock test module."""

--- a/tests/mock_module/__init__.py
+++ b/tests/mock_module/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
-# Invenio is free software; you can redistribute it and/or modify it
-# under the terms of the MIT License; see LICENSE file for more details.
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
 """Mock test module."""

--- a/tests/mock_module/mappings/__init__.py
+++ b/tests/mock_module/mappings/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Mappings directory."""

--- a/tests/mock_module/mappings/__init__.py
+++ b/tests/mock_module/mappings/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
-# Invenio is free software; you can redistribute it and/or modify it
-# under the terms of the MIT License; see LICENSE file for more details.
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
 """Mappings directory."""

--- a/tests/mock_module/mappings/v6/__init__.py
+++ b/tests/mock_module/mappings/v6/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Elasticsearch version 6 mappings."""

--- a/tests/mock_module/mappings/v6/__init__.py
+++ b/tests/mock_module/mappings/v6/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
-# Invenio is free software; you can redistribute it and/or modify it
-# under the terms of the MIT License; see LICENSE file for more details.
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
 """Elasticsearch version 6 mappings."""

--- a/tests/mock_module/mappings/v6/invenio-records-resources/testrecord.json
+++ b/tests/mock_module/mappings/v6/invenio-records-resources/testrecord.json
@@ -1,0 +1,11 @@
+{
+  "mappings": {
+    "testrecord": {
+      "properties": {
+        "title": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}

--- a/tests/mock_module/mappings/v7/__init__.py
+++ b/tests/mock_module/mappings/v7/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Elasticsearch version 7 mappings."""

--- a/tests/mock_module/mappings/v7/__init__.py
+++ b/tests/mock_module/mappings/v7/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
-# Invenio is free software; you can redistribute it and/or modify it
-# under the terms of the MIT License; see LICENSE file for more details.
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
 """Elasticsearch version 7 mappings."""

--- a/tests/mock_module/mappings/v7/invenio-records-resources/testrecord.json
+++ b/tests/mock_module/mappings/v7/invenio-records-resources/testrecord.json
@@ -1,0 +1,9 @@
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -55,7 +55,7 @@ def app_with_custom_minter(app):
     current_pidstore.minters['recid_v2'] = recid_minter_v2
 
 
-def test_create_read_record(client, input_record):
+def test_create_read_record(client, input_record, es_clear):
     """Test record creation."""
     # Create new record
     response = client.post(
@@ -82,7 +82,7 @@ def test_create_read_record(client, input_record):
         assert field in response_fields
 
 
-def test_create_search_record(client, input_record):
+def test_create_search_record(client, input_record, es_clear):
     """Test record search."""
     # Search records, should return empty
     response = client.get("/records", headers=HEADERS)
@@ -103,7 +103,7 @@ def test_create_search_record(client, input_record):
     assert response.status_code == 200
 
 
-def test_create_delete_record(client, input_record):
+def test_create_delete_record(client, input_record, es_clear):
     """Test record deletion."""
     # Create dummy record to test delete
     response = client.post(
@@ -125,7 +125,7 @@ def test_create_delete_record(client, input_record):
     assert response.status_code == 204
 
 
-def test_create_update_record(client, input_record):
+def test_create_update_record(client, input_record, es_clear):
     """Test record update."""
     # Create dummy record to test update
     response = client.post(
@@ -159,7 +159,7 @@ def test_create_update_record(client, input_record):
 #     # TODO: Assert
 
 
-def test_read_deleted_record(client, input_record):
+def test_read_deleted_record(client, input_record, es_clear):
     """Test read a deleted record."""
     # Create dummy record to test delete
     response = client.post(
@@ -179,7 +179,7 @@ def test_read_deleted_record(client, input_record):
     assert response.json['message'] == "The record has been deleted."
 
 
-def test_read_record_with_non_existing_pid(client, input_record):
+def test_read_record_with_non_existing_pid(client, input_record, es_clear):
     """Test read a record with a non existing pid."""
 
     response = client.get("/records/randomid", headers=HEADERS)
@@ -190,7 +190,7 @@ def test_read_record_with_non_existing_pid(client, input_record):
 
 
 def test_read_record_with_unregistered_pid(app_with_custom_minter,
-                                           input_record):
+                                           input_record, es_clear):
     """Test read a record with an unregistered pid."""
 
     client = app_with_custom_minter.test_client()
@@ -208,7 +208,7 @@ def test_read_record_with_unregistered_pid(app_with_custom_minter,
     assert response.json['message'] == "The pid is not registered."
 
 
-def test_read_record_with_redirected_pid(client, input_record):
+def test_read_record_with_redirected_pid(client, input_record, es_clear):
     """Test read a record with a redirected pid."""
 
     # Create dummy record
@@ -236,9 +236,8 @@ def test_read_record_with_redirected_pid(client, input_record):
     assert response.json['message'] == "Moved Permanently."
 
 
-def test_read_record_with_different_type_of_redirected_pid(app, client,
-                                                           input_record,
-                                                           monkeypatch):
+def test_read_record_with_different_type_of_redirected_pid(
+        app, client, input_record, monkeypatch, es_clear):
     """Test read a record with a redirected pid that is of different type."""
 
     # monkeypatch the `testing` flask attribute so exceptions

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -82,12 +82,6 @@ def test_create_read_record(client, input_record):
         assert field in response_fields
 
 
-# This test DOES NOT clean after itself. It works every time on CI,
-# because the CI creates a new container for each test run. It will work
-# once locally, but fail on subsequent run.
-# TODO: FIX to make it clean up itself. Adding es_clear didn't work
-@pytest.mark.skipif(
-    os.environ.get('CI') != 'true', reason="Fix to make it clean up itself")
 def test_create_search_record(client, input_record):
     """Test record search."""
     # Search records, should return empty
@@ -99,7 +93,6 @@ def test_create_search_record(client, input_record):
         "/records", headers=HEADERS, data=json.dumps(input_record)
     )
     assert response.status_code == 201
-    print("response.json", response.json)
 
     # Search content of record, should return the record
     response = client.get("/records?q=story", headers=HEADERS)


### PR DESCRIPTION
close #19 

`test_read_record_with_different_type_of_redirected_pid` is now failing on my machine... It actually raises the exception instead of serializing to a 500. I know pidstore and error handling have been modified recently. What am I missing? 