### PR TITLE
Search records epic

### DIFF
--- a/invenio_records_resources/config.py
+++ b/invenio_records_resources/config.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -14,9 +15,5 @@ lt_es7 = ES_VERSION[0] < 7
 
 PIDSTORE_RECID_FIELD = "recid"
 
-LINK_URLS = {
-    'record': '{base}/records/{pid}',
-    'records': '{base}/records/',
-}
-
+# TODO: Might be something to place with the fundamental invenio config
 SERVER_HOSTNAME = "localhost:5000"

--- a/invenio_records_resources/links.py
+++ b/invenio_records_resources/links.py
@@ -125,8 +125,13 @@ class ResourceListLinks:
         _links = {
             "self": self._links_self(),
         }
-        if self._links_prev():
-            _links["prev"] = self._links_prev()
-        if self._links_next():
-            _links["next"] = self._links_next()
+
+        prev_link = self._links_prev()
+        if prev_link:
+            _links["prev"] = prev_link
+
+        next_link = self._links_next()
+        if next_link:
+            _links["next"] = next_link
+
         return _links

--- a/invenio_records_resources/pagination.py
+++ b/invenio_records_resources/pagination.py
@@ -19,6 +19,8 @@ class PagedIndexes:
         :param size: int >= 1
         :param page: int >= 1
         :param max_results: int >= 1
+
+        These are validated in valid().
         """
         self.size = size
         self.page = page
@@ -31,7 +33,10 @@ class PagedIndexes:
 
     def valid(self):
         """Returns True if valid, False if not."""
-        return 0 <= self.from_idx < self.max_results
+        pre_condition = (
+            self.size >= 1 and self.page >= 1 and self.max_results >= 1
+        )
+        return pre_condition and 0 <= self.from_idx < self.max_results
 
     @property
     def to_idx(self):

--- a/invenio_records_resources/pagination.py
+++ b/invenio_records_resources/pagination.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Pagination functionality."""
+
+
+class PagedIndexes:
+    """Encapsulates pagination logic."""
+
+    def __init__(self, size, page, max_results):
+        """Constructor.
+
+        :param size: int >= 1
+        :param page: int >= 1
+        :param max_results: int >= 1
+        """
+        self.size = size
+        self.page = page
+        self.max_results = max_results
+
+    @property
+    def from_idx(self):
+        """Start index (with respect to all results) for this page."""
+        return (self.page - 1) * self.size
+
+    def valid(self):
+        """Returns True if valid, False if not."""
+        return 0 <= self.from_idx < self.max_results
+
+    @property
+    def to_idx(self):
+        """Stop index (with respect to all results) for this page.
+
+        The index is non-inclusive.
+        """
+        return min(self.page * self.size, self.max_results)
+
+    def prev_page(self):
+        """Returns the previous Page or None if no previous Page."""
+        page = PagedIndexes(self.size, self.page - 1, self.max_results)
+        return page if page.valid() else None
+
+    def next_page(self):
+        """Returns the previous Page or None if no previous Page."""
+        page = PagedIndexes(self.size, self.page + 1, self.max_results)
+        return page if page.valid() else None

--- a/invenio_records_resources/resource_units.py
+++ b/invenio_records_resources/resource_units.py
@@ -13,25 +13,33 @@
 class IdentifiedRecord:
     """Resource unit representing pid + Record data clump."""
 
-    def __init__(self, pid=None, record=None):
-        """Initialize the record state."""
+    def __init__(self, pid, record, links):
+        """Constructor."""
         self.id = pid.pid_value
         self.pids = [pid]
         self.record = record
+        self.links = links
 
     def is_revision(self, revision_id):
         """Check if record is in a specific revision."""
         return str(self.record.revision_id) == str(revision_id)
 
 
-class RecordSearchState:
-    """State object for objects associated with a record search."""
+class IdentifiedRecords:
+    """Resource list representing the result of an IdentifiedRecord search."""
 
-    def __init__(self, records, total, aggregations):
-        """Initialize the record state."""
+    def __init__(self, records, total, aggregations, links):
+        """Constructor.
+
+        :params records: iterable of records
+        :params total: total number of records
+        :params aggregations: dict of ES aggregations
+        :params search_args: dict(page, size, to_idx, from_idx, q)
+        """
         self.records = records
         self.total = total
         self.aggregations = aggregations
+        self.links = links
 
 
 class TombstoneState(IdentifiedRecord):

--- a/invenio_records_resources/resources/record_config.py
+++ b/invenio_records_resources/resources/record_config.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Record Resource Configuration."""
+
+from flask_resources.errors import HTTPJSONException, create_errormap_handler
+from flask_resources.loaders import RequestLoader
+from flask_resources.parsers import ArgsParser
+from flask_resources.resources import ResourceConfig
+from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError, \
+    PIDMissingObjectError, PIDRedirectedError, PIDUnregistered
+
+from ..errors import create_pid_redirected_error_handler
+from ..responses import RecordResponse
+from ..schemas import RecordSchemaJSONV1, SearchURLArgsSchemaV1
+from ..serializers import RecordJSONSerializer
+from ..services.errors import InvalidQueryError, PermissionDeniedError
+
+
+class RecordResourceConfig(ResourceConfig):
+    """Record resource config."""
+
+    # NOTE: These are defaults. They are superseded by config.py's
+    # RECORDS_RESOURCES_ROUTES
+    item_route = "/records/<pid_value>"
+    list_route = "/records"
+
+    request_url_args_parser = {
+        "search": ArgsParser(SearchURLArgsSchemaV1)
+    }
+
+    response_handlers = {
+        "application/json": RecordResponse(
+            RecordJSONSerializer(schema=RecordSchemaJSONV1)
+        )
+    }
+    error_map = {
+        InvalidQueryError: create_errormap_handler(
+            HTTPJSONException(
+                code=400,
+                description="Invalid query syntax.",
+            )
+        ),
+        PermissionDeniedError: create_errormap_handler(
+            HTTPJSONException(
+                code=403,
+                description="Permission denied.",
+            )
+        ),
+        PIDDeletedError: create_errormap_handler(
+            HTTPJSONException(
+                code=410,
+                description="The record has been deleted.",
+            )
+        ),
+        PIDDoesNotExistError: create_errormap_handler(
+            HTTPJSONException(
+                code=404,
+                description="The pid does not exist.",
+            )
+        ),
+        PIDUnregistered: create_errormap_handler(
+            HTTPJSONException(
+                code=404,
+                description="The pid is not registered.",
+            )
+        ),
+        PIDRedirectedError: create_pid_redirected_error_handler(),
+    }

--- a/invenio_records_resources/schemas/__init__.py
+++ b/invenio_records_resources/schemas/__init__.py
@@ -9,9 +9,11 @@
 """Marshmallow schemas for serialization."""
 
 from .json import MetadataSchemaJSONV1, Nested, RecordSchemaJSONV1
+from .url_args import SearchURLArgsSchemaV1
 
 __all__ = (
     "MetadataSchemaJSONV1",
-    "RecordSchemaJSONV1",
     "Nested",
+    "RecordSchemaJSONV1",
+    "SearchURLArgsSchemaV1"
 )

--- a/invenio_records_resources/schemas/url_args.py
+++ b/invenio_records_resources/schemas/url_args.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Marshmallow JSON schema."""
+
+
+from marshmallow import Schema, ValidationError, fields, post_load, validate, \
+    validates_schema
+
+from ..pagination import PagedIndexes
+
+# TODO: Make configurable
+DEFAULT_RESULTS_PER_PAGE = 25
+DEFAULT_MAX_RESULTS = 10000
+
+
+class PaginationURLArgsSchemaV1(Schema):
+    """Schema for pagination URL args."""
+
+    page = fields.Int(validate=validate.Range(min=1), missing=1)
+    size = fields.Int(
+        validate=validate.Range(min=1, max=DEFAULT_MAX_RESULTS),
+        missing=DEFAULT_RESULTS_PER_PAGE
+    )
+
+    @validates_schema
+    def validate_pagination(self, data, **kwargs):
+        """Validate pagination args make sense."""
+        page = PagedIndexes(data["size"], data["page"], DEFAULT_MAX_RESULTS)
+        if not page.valid():
+            raise ValidationError("Invalid pagination parameters.")
+
+    @post_load
+    def from_and_to_idx(self, data, **kwargs):
+        """Inject from_idx and to_idx into data bc they are valid."""
+        page = PagedIndexes(data["size"], data["page"], DEFAULT_MAX_RESULTS)
+        data["from_idx"] = page.from_idx
+        data["to_idx"] = page.to_idx
+        return data
+
+
+class SearchURLArgsSchemaV1(PaginationURLArgsSchemaV1):
+    """Schema for search URL args."""
+
+    q = fields.String()

--- a/invenio_records_resources/serializers/json.py
+++ b/invenio_records_resources/serializers/json.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -12,8 +13,6 @@ import json
 
 import pytz
 from flask_resources.serializers import SerializerMixin
-
-from ..links import link_for, search_links
 
 
 class RecordJSONSerializer(SerializerMixin):
@@ -40,10 +39,7 @@ class RecordJSONSerializer(SerializerMixin):
                 if record.updated and not record.updated.tzinfo
                 else None
             ),
-            links=dict(
-                self=link_for(api=True, tpl_key='record', pid=pid),
-                self_html=link_for(api=False, tpl_key='record', pid=pid),
-            )
+            links=record_state.links
         )
 
         return record_dict
@@ -60,10 +56,8 @@ class RecordJSONSerializer(SerializerMixin):
     ):
         """Dump the object list into a json string.
 
-        :param: obj_list a RecordSearchState object
+        :param: obj_list a IdentifiedRecords object
         """
-        url_args = response_ctx.get("url_args") if response_ctx else {}
-
         serialized_content = {
             "hits": {
                 "hits": [
@@ -72,7 +66,7 @@ class RecordJSONSerializer(SerializerMixin):
                 ],
                 "total": obj_list.total
             },
-            "links": search_links(url_args=url_args, total=obj_list.total),
+            "links": obj_list.links,
             "aggregations": obj_list.aggregations
         }
 

--- a/invenio_records_resources/serializers/xml.py
+++ b/invenio_records_resources/serializers/xml.py
@@ -32,6 +32,6 @@ class RecordXMLSerializer(SerializerMixin):
     ):
         """Dump the object list into an XML string.
 
-        :param: obj_list a RecordSearchState object
+        :param: obj_list an IdentifiedRecords object
         """
         raise NotImplementedError()

--- a/invenio_records_resources/services/file_metadata.py
+++ b/invenio_records_resources/services/file_metadata.py
@@ -11,7 +11,7 @@
 
 from invenio_records_permissions.policies.records import RecordPermissionPolicy
 
-from ..resource_units import IdentifiedRecord, RecordSearchState
+from ..resource_units import IdentifiedRecord, IdentifiedRecords
 from .service import Service, ServiceConfig
 
 

--- a/invenio_records_resources/services/service.py
+++ b/invenio_records_resources/services/service.py
@@ -54,7 +54,7 @@ class Service:
         of a Resource. It is what a Resource transacts in and therefore
         what a Service must provide.
         """
-        return self.config.resource_unit_cls(**kwargs)
+        return self.config.resource_unit_cls(*args, **kwargs)
 
     def resource_list(self, *args, **kwargs):
         """Create a new instance of the resource list.

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test links."""
+
+from invenio_records_resources.links import ResourceUnitLinks
+
+
+def test_resource_unit_links(app):
+    links = ResourceUnitLinks("/records/<pid_value>", "12345-abcde").links()
+
+    expected_links = {
+        "self": "https://localhost:5000/api/records/12345-abcde",
+        "self_html": "https://localhost:5000/records/12345-abcde",
+    }
+    assert expected_links == links

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test pagination."""
+
+import json
+from copy import deepcopy
+
+import pytest
+from flask_principal import Identity, Need, UserNeed
+from invenio_search import current_search
+
+from invenio_records_resources.schemas.url_args import DEFAULT_MAX_RESULTS, \
+    DEFAULT_RESULTS_PER_PAGE
+from invenio_records_resources.services import RecordService
+
+HEADERS = {"content-type": "application/json", "accept": "application/json"}
+
+# 2 things to test
+# 1- results are paginated
+# 2- links are generated
+
+
+@pytest.fixture("module")
+def identity_simple():
+    """Simple identity fixture."""
+    i = Identity(1)
+    i.provides.add(UserNeed(1))
+    i.provides.add(Need(method='system_role', value='any_user'))
+    return i
+
+
+@pytest.fixture("module")
+def three_indexed_records(app, input_service_data, identity_simple, es):
+    # NOTE: We make use of es fixture (and not es_clear) here because all tests
+    #       assume 3 records have been indexed and NO tests in this module
+    #       adds/deletes any.
+    record_service = RecordService()
+    search_class = record_service.config.search_cls
+    for i in range(3):
+        data = deepcopy(input_service_data)
+        data["title"] += f" {i}"
+        record_service.create(data, identity_simple)
+        current_search.flush_and_refresh(search_class.Meta.index)
+
+
+#
+# 1- results are paginated
+#
+
+
+def assert_hits_len(response, expected_hits):
+    """Assert number of hits."""
+    assert response.status_code == 200
+    assert len(response.json['hits']['hits']) == expected_hits
+
+
+def test_pagination_defaults(client, three_indexed_records):
+    # Test that default querystring pagination values are used if none
+    # specified. Those should allow for 3 records to show up in response.
+    response = client.get("/records", headers=HEADERS)
+
+    assert_hits_len(response, 3)
+
+
+def test_pagination_page(client, three_indexed_records):
+    response = client.get("/records?page=1", headers=HEADERS)
+    assert_hits_len(response, 3)
+
+    response = client.get("/records?page=2", headers=HEADERS)
+    assert_hits_len(response, 0)
+
+    invalid_page = DEFAULT_MAX_RESULTS // DEFAULT_RESULTS_PER_PAGE + 1
+    response = client.get(
+        "/records?page={}".format(invalid_page),
+        headers=HEADERS
+    )
+    assert response.status_code == 400
+
+
+def test_pagination_size(client, three_indexed_records):
+    response = client.get("/records?size=10", headers=HEADERS)
+    assert_hits_len(response, 3)
+
+    response = client.get("/records?size=1", headers=HEADERS)
+    assert_hits_len(response, 1)
+
+    response = client.get("/records?size=0", headers=HEADERS)
+    assert response.status_code == 400
+
+    invalid_size = DEFAULT_MAX_RESULTS + 1
+    response = client.get(
+        "/records?size={}".format(invalid_size),
+        headers=HEADERS
+    )
+    assert response.status_code == 400
+
+
+def test_pagination_page_and_size(client, three_indexed_records):
+    response = client.get("/records?size=10&page=1", headers=HEADERS)
+    assert_hits_len(response, 3)
+
+    response = client.get("/records?page=2&size=1", headers=HEADERS)
+    assert_hits_len(response, 1)
+
+    response = client.get("/records?page=20size=1000", headers=HEADERS)
+    assert response.status_code == 400
+
+
+#
+# 2- links are generated
+#
+
+def test_middle_search_result_has_next_and_prev_links(
+        client, three_indexed_records):
+    response = client.get("/records?size=1&page=2", headers=HEADERS)
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": "https://localhost:5000/api/records?size=1&page=2",
+        "prev": "https://localhost:5000/api/records?size=1&page=1",
+        "next": "https://localhost:5000/api/records?size=1&page=3",
+    }
+    # NOTE: This is done so that we only test for pagination links
+    for key, url in expected_links.items():
+        assert url == response_links[key]
+
+
+def test_first_search_result_has_next_and_no_prev_link(
+        client, three_indexed_records):
+    response = client.get("/records?size=1&page=1", headers=HEADERS)
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": "https://localhost:5000/api/records?size=1&page=1",
+        "next": "https://localhost:5000/api/records?size=1&page=2",
+    }
+    # NOTE: This is done so that we only test for pagination links
+    for key, url in expected_links.items():
+        assert url == response_links[key]
+
+    assert "prev" not in response_links
+
+
+def test_last_search_result_has_next_and_prev_links(
+        client, three_indexed_records):
+    # NOTE: We are replicating invenio-records-rest approach which could be
+    #       discussed.
+    response = client.get("/records?size=1&page=3", headers=HEADERS)
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": "https://localhost:5000/api/records?size=1&page=3",
+        "prev": "https://localhost:5000/api/records?size=1&page=2",
+        "next": "https://localhost:5000/api/records?size=1&page=4",
+    }
+    # NOTE: This is done so that we only test for pagination links
+    for key, url in expected_links.items():
+        assert url == response_links[key]
+
+
+def test_max_search_result_has_prev_and_no_next_link(
+        client, three_indexed_records):
+    # NOTE: We are replicating invenio-records-rest approach which could be
+    #       discussed.
+    max_results = DEFAULT_MAX_RESULTS
+
+    response = client.get(
+        f"/records?size=1&page={max_results}",
+        headers=HEADERS
+    )
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": (
+            f"https://localhost:5000/api/records?size=1&page={max_results}"
+        ),
+        "prev": (
+            f"https://localhost:5000/api/records?size=1&page={max_results - 1}"
+        ),
+    }
+    # NOTE: This is done so that we only test for pagination links
+    for key, url in expected_links.items():
+        assert url == response_links[key]
+
+    assert "next" not in response_links
+
+
+def test_searchstring_is_preserved(client, three_indexed_records):
+    response = client.get(
+        "/records?size=1&page=2&q=Romans+story",
+        headers=HEADERS
+    )
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": (
+            "https://localhost:5000/api/records?size=1&page=2&q=Romans+story"
+        ),
+        "prev": (
+            "https://localhost:5000/api/records?size=1&page=1&q=Romans+story"
+        ),
+        "next": (
+            "https://localhost:5000/api/records?size=1&page=3&q=Romans+story"
+        ),
+    }
+    # NOTE: This is done so that we only test for pagination links
+    for key, url in expected_links.items():
+        assert url == response_links[key]

--- a/tests/test_serialization_integration.py
+++ b/tests/test_serialization_integration.py
@@ -18,7 +18,8 @@ from invenio_records_resources.responses import RecordResponse
 from invenio_records_resources.schemas import RecordSchemaJSONV1
 from invenio_records_resources.serializers import RecordJSONSerializer, \
     RecordXMLSerializer
-from invenio_records_resources.services import RecordService
+from invenio_records_resources.services import RecordService, \
+    RecordServiceConfig
 
 HEADERS = {"content-type": "application/json", "accept": "application/json"}
 
@@ -36,17 +37,26 @@ class CustomRecordResourceConfig(RecordResourceConfig):
     }
 
 
+class CustomRecordServiceConfig(RecordServiceConfig):
+    """Custom record resource config."""
+
+    item_route = CustomRecordResourceConfig.item_route
+    list_route = CustomRecordResourceConfig.list_route
+
+
 @pytest.fixture(scope="module")
 def app(app):
     """Application factory fixture."""
-    custom_bp = RecordResource(
+    resource = RecordResource(
         config=CustomRecordResourceConfig,
-        service=RecordService()).as_blueprint("custom_resource")
+        service=RecordService(CustomRecordServiceConfig)
+    )
+    custom_bp = resource.as_blueprint("custom_resource")
     app.register_blueprint(custom_bp)
     yield app
 
 
-def test_create_read_xml_record(client, input_record):
+def test_create_read_xml_record(app, client, input_record):
     # Create new record
     response = client.post(
         "/serialization_test/records", headers=HEADERS,


### PR DESCRIPTION
- parse URL querystring
    * size
    * page
    * q
- generate search self, next, prev links
- generate read self, self_html
- pass down URL routes from RecordServiceConfig
    * required splitting ResourceRecordconfig in own file
- keeps ResourceUnit + ResourceList as data containers
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/212
- closes #33 
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/131