### PR TITLE
links: access config in app context

### DIFF
--- a/invenio_records_resources/links.py
+++ b/invenio_records_resources/links.py
@@ -185,15 +185,25 @@ class RecordSelfHtmlLinkBuilder(RecordLinkBuilder):
 
     def __init__(self, config):
         """Constructor."""
-        super(RecordSelfHtmlLinkBuilder, self).__init__(
-            key="self_html",
-            route=(
-                current_app.config.get("RECORDS_UI_ENDPOINTS", {})
-                .get("recid", {})
-                .get("route")
-            ),
-            action="read",
-            permission_policy=config.permission_policy_cls
+        self.key = "self_html"
+        self.action = "read"
+        self.permission_policy = config.permission_policy_cls
+
+    @property
+    def route(self):
+        """Returns the route.
+
+        Problem: `current_app.config` cannot be called in the constructor since
+                 constructor is called outside of an application context.
+        Temporary solution: call `current_app.config` only when `.route` is
+                            called since `.route` is only called in an
+                            application context.
+        TODO: Longer-term solution should be addressed by issue #67
+        """
+        return (
+            current_app.config.get("RECORDS_UI_ENDPOINTS", {})
+            .get("recid", {})
+            .get("route")
         )
 
 

--- a/invenio_records_resources/version.py
+++ b/invenio_records_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_records_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
- Instead of accessing config in constructor, config is
  accessed when `.route` is called which is always in
  app context.
- bumps version to 0.4.1

This is part of making a working August release and will be merged and deployed when it passes.