### PR TITLE
links: revert self_html back into __init__ [more]

### DIFF
--- a/invenio_records_resources/links.py
+++ b/invenio_records_resources/links.py
@@ -170,33 +170,6 @@ class RecordSelfLinkBuilder(RecordLinkBuilder):
         )
 
 
-class RecordSelfHtmlLinkBuilder(RecordLinkBuilder):
-    """Builds record "self_html" link."""
-
-    def __init__(self, config):
-        """Constructor."""
-        self.key = "self_html"
-        self.action = "read"
-        self.permission_policy = config.permission_policy_cls
-
-    @property
-    def route(self):
-        """Returns the route.
-
-        Problem: `current_app.config` cannot be called in the constructor since
-                 constructor is called outside of an application context.
-        Temporary solution: call `current_app.config` only when `.route` is
-                            called since `.route` is only called in an
-                            application context.
-        TODO: Longer-term solution should be addressed by issue #67
-        """
-        return (
-            current_app.config.get("RECORDS_UI_ENDPOINTS", {})
-            .get("recid", {})
-            .get("route")
-        )
-
-
 class RecordDeleteLinkBuilder(RecordLinkBuilder):
     """Builds record "delete" link."""
 

--- a/invenio_records_resources/services/record.py
+++ b/invenio_records_resources/services/record.py
@@ -20,8 +20,7 @@ from invenio_search import RecordsSearch
 
 from ..config import lt_es7
 from ..links import Linker, RecordDeleteLinkBuilder, RecordFilesLinkBuilder, \
-    RecordSearchLinkBuilder, RecordSelfHtmlLinkBuilder, \
-    RecordSelfLinkBuilder
+    RecordSearchLinkBuilder, RecordSelfLinkBuilder
 from ..resource_units import IdentifiedRecord, IdentifiedRecords
 from ..resources.record_config import RecordResourceConfig
 from .data_validator import MarshmallowDataValidator
@@ -71,7 +70,6 @@ class RecordServiceConfig(ServiceConfig):
     record_files_route = RecordResourceConfig.item_route + "/files"
     record_link_builders = [
         RecordSelfLinkBuilder,
-        RecordSelfHtmlLinkBuilder,
         RecordDeleteLinkBuilder,
         RecordFilesLinkBuilder,
     ]

--- a/tests/services/test_links.py
+++ b/tests/services/test_links.py
@@ -46,7 +46,6 @@ def test_record_links(app, identity_simple, input_service_data, es):
 
     expected_links = {
         "self": f"https://localhost:5000/api/records/{pid_value}",
-        "self_html": f"https://localhost:5000/records/{pid_value}",
         "delete": f"https://localhost:5000/api/records/{pid_value}",
         # NOTE: Generate the link even if no file(s) for now
         "files": f"https://localhost:5000/api/records/{pid_value}/files",


### PR DESCRIPTION
LinkBuilders are now initialized in an app_context, so
no need for trick anymore.

part of https://github.com/inveniosoftware/invenio-app-rdm/issues/232