### PR TITLE
search: test sort, facet, pagination endpoints [+]

### DIFF
--- a/invenio_records_resources/pagination.py
+++ b/invenio_records_resources/pagination.py
@@ -29,7 +29,7 @@ class Pagination:
     def valid(self):
         """Returns True if valid, False if not."""
         pre_condition = (
-            self.size >= 1 and self.page >= 1 and self.max_results >= 1
+            1 <= self.size <= self.max_results and 1 <= self.page
         )
         return pre_condition and 0 <= self.from_idx < self.max_results
 

--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -11,6 +11,7 @@
 import json
 
 from flask import jsonify, make_response, request, url_for
+from flask_resources.errors import HTTPJSONException, create_errormap_handler
 from werkzeug.routing import BuildError
 
 
@@ -40,3 +41,11 @@ def create_pid_redirected_error_handler():
             raise e
 
     return pid_redirected_error_handler
+
+
+handle_querystring_validation_error = create_errormap_handler(
+    HTTPJSONException(
+        code=400,
+        description="Invalid querystring parameters.",
+    )
+)

--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -8,10 +8,7 @@
 
 """Invenio Resources module to create REST APIs."""
 
-import json
-
 from flask import jsonify, make_response, request, url_for
-from flask_resources.errors import HTTPJSONException, create_errormap_handler
 from werkzeug.routing import BuildError
 
 
@@ -41,11 +38,3 @@ def create_pid_redirected_error_handler():
             raise e
 
     return pid_redirected_error_handler
-
-
-handle_querystring_validation_error = create_errormap_handler(
-    HTTPJSONException(
-        code=400,
-        description="Invalid querystring parameters.",
-    )
-)

--- a/invenio_records_resources/resources/record_args.py
+++ b/invenio_records_resources/resources/record_args.py
@@ -13,7 +13,6 @@
 from marshmallow import Schema, fields, validate
 
 
-
 class SearchURLArgsSchema(Schema):
     """Schema for search URL args."""
 

--- a/invenio_records_resources/resources/record_args.py
+++ b/invenio_records_resources/resources/record_args.py
@@ -10,13 +10,8 @@
 """Schemas for parameter parsing."""
 
 
-from marshmallow import Schema, ValidationError, fields, post_load, validate, \
-    validates_schema
+from marshmallow import Schema, fields, validate
 
-from ..pagination import Pagination
-
-DEFAULT_RESULTS_PER_PAGE = 25
-DEFAULT_MAX_RESULTS = 10000
 
 
 class SearchURLArgsSchema(Schema):
@@ -24,31 +19,8 @@ class SearchURLArgsSchema(Schema):
 
     q = fields.String()
     sort = fields.String()
-    page = fields.Int(validate=validate.Range(min=1), missing=1)
-    size = fields.Int(
-        validate=validate.Range(min=1, max=DEFAULT_MAX_RESULTS),
-        missing=DEFAULT_RESULTS_PER_PAGE
-    )
-    # from_ = fields.Int(
-    #     validate=validate.Range(min=1), load_from='from', dump_to='from')
-
-    @validates_schema
-    def validate_pagination(self, data, **kwargs):
-        """Validate pagination args make sense."""
-        # if "page" in data and "from" in data:
-        #     raise ValidationError(
-        #         "The query parameters 'from' and 'page' must not be used at "
-        #         "the same time."
-        #     )
-        page = Pagination(data["size"], data["page"], DEFAULT_MAX_RESULTS)
-        if not page.valid():
-            raise ValidationError("Invalid pagination parameters.")
-
-    @post_load
-    def _max_results(self, data, **kwargs):
-        """Inject from_idx and to_idx into data bc they are valid."""
-        data["_max_results"] = DEFAULT_MAX_RESULTS
-        return data
+    page = fields.Int(validate=validate.Range(min=1))
+    size = fields.Int(validate=validate.Range(min=1))
 
 
 class RequestHeadersSchema(Schema):

--- a/invenio_records_resources/resources/record_config.py
+++ b/invenio_records_resources/resources/record_config.py
@@ -61,6 +61,12 @@ class RecordResourceConfig(ResourceConfig):
                 description=e.description,
             )
         ),
+        QuerystringValidationError: create_errormap_handler(
+            HTTPJSONException(
+                code=400,
+                description="Invalid querystring parameters.",
+            )
+        ),
         PermissionDeniedError: create_errormap_handler(
             HTTPJSONException(
                 code=403,

--- a/invenio_records_resources/resources/record_config.py
+++ b/invenio_records_resources/resources/record_config.py
@@ -17,7 +17,8 @@ from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError, \
     PIDRedirectedError, PIDUnregistered
 from uritemplate import URITemplate
 
-from ..services.errors import PermissionDeniedError, RevisionIdMismatchError
+from ..services.errors import PermissionDeniedError, \
+    QuerystringValidationError, RevisionIdMismatchError
 from .errors import create_pid_redirected_error_handler
 from .record_args import RequestHeadersSchema, SearchURLArgsSchema
 from .record_response import RecordResponse

--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -36,4 +36,5 @@ class RevisionIdMismatchError(Exception):
         )
 
 
-class QuerystringValidationError(ValidationError):    ss"""Error thrown when there is an issue with the querystring."""    passs
+class QuerystringValidationError(ValidationError):
+    """Error thrown when there is an issue with the querystring."""

--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,6 +10,7 @@
 """Errors."""
 
 from flask_principal import PermissionDenied
+from marshmallow import ValidationError
 
 
 class PermissionDeniedError(PermissionDenied):
@@ -32,3 +34,6 @@ class RevisionIdMismatchError(Exception):
             f"Revision id provided({self.expected_revision_id}) doesn't match "
             f"record's one({self.record_revision_id})"
         )
+
+
+class QuerystringValidationError(ValidationError):    ss"""Error thrown when there is an issue with the querystring."""    passs

--- a/invenio_records_resources/services/records/config.py
+++ b/invenio_records_resources/services/records/config.py
@@ -38,24 +38,37 @@ class RecordServiceConfig(ServiceConfig):
     record_cls = Record
     indexer_cls = RecordIndexer
 
+    # # Search configuration
     search_cls = RecordsSearchV2
     search_query_parser_cls = QueryParser
     search_sort_default = 'bestmatch'
     search_sort_default_no_query = 'mostrecent'
-    search_sort_options = dict(
-        bestmatch=dict(
+    search_sort_options = {
+        "bestmatch": dict(
             title=_('Best match'),
             fields=['_score'],  # ES defaults to desc on `_score` field
         ),
-        mostrecent=dict(
+        "-bestmatch": dict(
+            title=_('Worst match'),
+            fields=['-_score'],
+        ),
+        "mostrecent": dict(
             title=_('Most recent'),
             fields=['-created'],
         ),
-    )
+        "-mostrecent": dict(
+            title=_('Least recent'),
+            fields=['created'],
+        ),
+    }
     search_facets_options = dict(
         aggs={},
         post_filters={}
     )
+    search_pagination_options = {
+        "default_results_per_page": 25,
+        "default_max_results": 10000
+    }
     search_params_interpreters_cls = [
         QueryStrParam,
         PaginationParam,

--- a/invenio_records_resources/services/records/config.py
+++ b/invenio_records_resources/services/records/config.py
@@ -42,22 +42,18 @@ class RecordServiceConfig(ServiceConfig):
     search_cls = RecordsSearchV2
     search_query_parser_cls = QueryParser
     search_sort_default = 'bestmatch'
-    search_sort_default_no_query = 'mostrecent'
+    search_sort_default_no_query = 'newest'
     search_sort_options = {
         "bestmatch": dict(
             title=_('Best match'),
             fields=['_score'],  # ES defaults to desc on `_score` field
         ),
-        "-bestmatch": dict(
-            title=_('Worst match'),
-            fields=['-_score'],
-        ),
-        "mostrecent": dict(
-            title=_('Most recent'),
+        "newest": dict(
+            title=_('Newest'),
             fields=['-created'],
         ),
-        "-mostrecent": dict(
-            title=_('Least recent'),
+        "oldest": dict(
+            title=_('Oldest'),
             fields=['created'],
         ),
     }

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -14,6 +14,7 @@ fixtures are available.
 """
 
 import pytest
+from flask_principal import Identity, Need, UserNeed
 from mock_module.resource import Resource, ResourceConfig
 from mock_module.service import Service, ServiceConfig
 
@@ -36,3 +37,12 @@ def base_app(base_app, resource):
     base_app.register_blueprint(resource.as_blueprint('mock'))
     # base_app.register_error_handler(HTTPException, handle_http_exception)
     yield base_app
+
+
+@pytest.fixture(scope="module")
+def identity_simple():
+    """Simple identity fixture."""
+    i = Identity(1)
+    i.provides.add(UserNeed(1))
+    i.provides.add(Need(method='system_role', value='any_user'))
+    return i

--- a/tests/resources/test_faceting.py
+++ b/tests/resources/test_faceting.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test faceting."""
+
+import time
+from copy import deepcopy
+
+import pytest
+from flask_principal import Identity, Need, UserNeed
+from invenio_search import current_search
+from mock_module.service import Service
+
+HEADERS = {"content-type": "application/json", "accept": "application/json"}
+
+
+# 2 things to test
+# 1- results are aggregated / post_filtered
+# 2- links are generated
+
+
+@pytest.fixture("module")
+def three_indexed_records(app, identity_simple, es):
+    # NOTE: es is used (and not es_clear) here because all tests
+    #       assume 3 records have been indexed and NO tests in this module
+    #       adds/deletes any.
+    service = Service()
+
+    def _create(metadata):
+        data = {
+            'metadata': {
+                'title': 'Test',
+                **metadata
+            },
+        }
+        service.create(identity_simple, data)
+
+    _create({"title": "Record 1", "type": {"type": "A", "subtype": "AA"}})
+    _create({"title": "Record 2", "type": {"type": "A", "subtype": "AB"}})
+    _create({"title": "Record 3", "type": {"type": "B"}})
+
+    current_search.flush_and_refresh("*")
+
+
+# Q: Are '+' not dealt with appropriately when generating links?
+# Q: Is api/ prefix not dealt with appropriately when generating links?
+
+
+#
+# 1- results are aggregated / post_filtered
+#
+
+def test_aggregating(client, three_indexed_records):
+    response = client.get("/mocks", headers=HEADERS)
+    response_aggs = response.json["aggregations"]
+
+    expected_aggs = {
+        "type": {
+            "buckets": [
+                {
+                    "doc_count": 2,
+                    "key": "A",
+                    "subtype": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "key": "AA"
+                            },
+                            {
+                                "doc_count": 1,
+                                "key": "AB"
+                            }
+                        ],
+                        'doc_count_error_upper_bound': 0,
+                        'sum_other_doc_count': 0
+                    }
+                },
+                {
+                    "doc_count": 1,
+                    "key": "B",
+                    "subtype": {
+                        "buckets": [],
+                        'doc_count_error_upper_bound': 0,
+                        'sum_other_doc_count': 0
+                    }
+                }
+            ],
+            'doc_count_error_upper_bound': 0,
+            'sum_other_doc_count': 0,
+        }
+    }
+    assert expected_aggs == response_aggs
+
+
+def test_post_filtering(client, three_indexed_records):
+    response = client.get("/mocks?type=A", headers=HEADERS)
+
+    assert response.status_code == 200
+
+    # Test aggregation is the same
+    response_aggs = response.json["aggregations"]
+    expected_aggs = {
+        "type": {
+            "buckets": [
+                {
+                    "doc_count": 2,
+                    "key": "A",
+                    "subtype": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "key": "AA"
+                            },
+                            {
+                                "doc_count": 1,
+                                "key": "AB"
+                            }
+                        ],
+                        'doc_count_error_upper_bound': 0,
+                        'sum_other_doc_count': 0
+                    }
+                },
+                {
+                    "doc_count": 1,
+                    "key": "B",
+                    "subtype": {
+                        "buckets": [],
+                        'doc_count_error_upper_bound': 0,
+                        'sum_other_doc_count': 0
+                    }
+                }
+            ],
+            'doc_count_error_upper_bound': 0,
+            'sum_other_doc_count': 0,
+        }
+    }
+    assert expected_aggs == response_aggs
+
+    # Test hits are filtered
+    response_hits = response.json["hits"]["hits"]
+    assert 2 == len(response_hits)
+    assert set(["Record 1", "Record 2"]) == set(
+        [h["metadata"]["title"] for h in response_hits]
+    )
+
+
+#
+# 2- links are generated
+#
+@pytest.mark.skip()
+def test_links_keep_facets(client, three_indexed_records):
+    response = client.get(
+        "/mocks?type=A&subtype=B",
+        headers=HEADERS
+    )
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": (
+            "https://localhost:5000/mocks?"
+            "page=1&size=25&sort=mostrecent&subtype=B&type=A"
+        ),
+        "next": (
+            "https://localhost:5000/api/records?"
+            "page=2&size=25&sort=mostrecent&subtype=B&type=A"
+        ),
+    }
+    for key, url in expected_links.items():
+        assert url == response_links[key]
+
+
+@pytest.mark.skip()
+def test_links_keep_repeated_facets(client, three_indexed_records):
+    response = client.get(
+        "/mocks?type=B&type=A",
+        headers=HEADERS
+    )
+
+    response_links = response.json["links"]
+    expected_links = {
+        "self": (
+            "https://localhost:5000/api/records?page=1&size=25&sort=mostrecent"
+            "&type=A&type=B"
+        ),
+        "next": (
+            "https://localhost:5000/api/records?page=2&size=25&sort=mostrecent"
+            "&type=A&type=B"
+        ),
+    }
+    for key, url in expected_links.items():
+        assert url == response_links[key]

--- a/tests/resources/test_resource_pagination.py
+++ b/tests/resources/test_resource_pagination.py
@@ -13,12 +13,8 @@ import json
 from copy import deepcopy
 
 import pytest
-from flask_principal import Identity, Need, UserNeed
 from invenio_search import current_search
-
-from invenio_records_resources.resources.record_args import \
-    DEFAULT_MAX_RESULTS, DEFAULT_RESULTS_PER_PAGE
-from invenio_records_resources.services import RecordService
+from mock_module.service import Service
 
 HEADERS = {"content-type": "application/json", "accept": "application/json"}
 
@@ -28,26 +24,28 @@ HEADERS = {"content-type": "application/json", "accept": "application/json"}
 
 
 @pytest.fixture("module")
-def identity_simple():
-    """Simple identity fixture."""
-    i = Identity(1)
-    i.provides.add(UserNeed(1))
-    i.provides.add(Need(method='system_role', value='any_user'))
-    return i
-
-
-@pytest.fixture("module")
-def three_indexed_records(app, input_service_data, identity_simple, es):
+def three_indexed_records(app, identity_simple, es):
     # NOTE: We make use of es fixture (and not es_clear) here because all tests
     #       assume 3 records have been indexed and NO tests in this module
     #       adds/deletes any.
-    record_service = RecordService()
-    search_class = record_service.config.search_cls
+    service = Service()
+
     for i in range(3):
-        data = deepcopy(input_service_data)
-        data["title"] += f" {i}"
-        record_service.create(identity_simple, data)
-        current_search.flush_and_refresh(search_class.Meta.index)
+        data = {
+            'metadata': {
+                'title': f"Test {i}",
+            },
+        }
+        service.create(identity_simple, data)
+
+    current_search.flush_and_refresh("*")
+
+
+@pytest.fixture("module")
+def search_options(app):
+    service = Service()
+    options = service.config.search_pagination_options
+    return options
 
 
 #
@@ -57,63 +55,57 @@ def three_indexed_records(app, input_service_data, identity_simple, es):
 
 def assert_hits_len(response, expected_hits):
     """Assert number of hits."""
-    assert response.status_code == 200
-    assert len(response.json['hits']['hits']) == expected_hits
+    assert 200 == response.status_code
+    assert expected_hits == len(response.json['hits']['hits'])
 
 
-@pytest.mark.skip()
 def test_pagination_defaults(client, three_indexed_records):
     # Test that default querystring pagination values are used if none
     # specified. Those should allow for 3 records to show up in response.
-    response = client.get("/records", headers=HEADERS)
+    response = client.get("/mocks", headers=HEADERS)
 
     assert_hits_len(response, 3)
 
 
-@pytest.mark.skip()
-def test_pagination_page(client, three_indexed_records):
-    response = client.get("/records?page=1", headers=HEADERS)
+def test_pagination_page(client, search_options, three_indexed_records):
+    response = client.get("/mocks?page=1", headers=HEADERS)
     assert_hits_len(response, 3)
 
-    response = client.get("/records?page=2", headers=HEADERS)
+    response = client.get("/mocks?page=2", headers=HEADERS)
     assert_hits_len(response, 0)
 
-    invalid_page = DEFAULT_MAX_RESULTS // DEFAULT_RESULTS_PER_PAGE + 1
-    response = client.get(
-        "/records?page={}".format(invalid_page),
-        headers=HEADERS
-    )
+    default_max_results = search_options["default_max_results"]
+    default_size = search_options["default_results_per_page"]
+    invalid_page = default_max_results // default_size + 1
+
+    response = client.get(f"/mocks?page={invalid_page}", headers=HEADERS)
     assert response.status_code == 400
 
 
-@pytest.mark.skip()
-def test_pagination_size(client, three_indexed_records):
-    response = client.get("/records?size=10", headers=HEADERS)
+def test_pagination_size(client, search_options, three_indexed_records):
+    response = client.get("/mocks?size=10", headers=HEADERS)
     assert_hits_len(response, 3)
 
-    response = client.get("/records?size=1", headers=HEADERS)
+    response = client.get("/mocks?size=1", headers=HEADERS)
     assert_hits_len(response, 1)
 
-    response = client.get("/records?size=0", headers=HEADERS)
+    response = client.get("/mocks?size=0", headers=HEADERS)
     assert response.status_code == 400
 
-    invalid_size = DEFAULT_MAX_RESULTS + 1
-    response = client.get(
-        "/records?size={}".format(invalid_size),
-        headers=HEADERS
-    )
+    default_max_results = search_options["default_max_results"]
+    invalid_size = default_max_results + 1
+    response = client.get(f"/mocks?size={invalid_size}", headers=HEADERS)
     assert response.status_code == 400
 
 
-@pytest.mark.skip()
 def test_pagination_page_and_size(client, three_indexed_records):
-    response = client.get("/records?size=10&page=1", headers=HEADERS)
+    response = client.get("/mocks?size=10&page=1", headers=HEADERS)
     assert_hits_len(response, 3)
 
-    response = client.get("/records?page=2&size=1", headers=HEADERS)
+    response = client.get("/mocks?page=2&size=1", headers=HEADERS)
     assert_hits_len(response, 1)
 
-    response = client.get("/records?page=20size=1000", headers=HEADERS)
+    response = client.get("/mocks?page=20size=1000", headers=HEADERS)
     assert response.status_code == 400
 
 
@@ -123,13 +115,13 @@ def test_pagination_page_and_size(client, three_indexed_records):
 @pytest.mark.skip()
 def test_middle_search_result_has_next_and_prev_links(
         client, three_indexed_records):
-    response = client.get("/records?size=1&page=2", headers=HEADERS)
+    response = client.get("/mocks?size=1&page=2", headers=HEADERS)
 
     response_links = response.json["links"]
     expected_links = {
-        "self": "https://localhost:5000/api/records?size=1&page=2",
-        "prev": "https://localhost:5000/api/records?size=1&page=1",
-        "next": "https://localhost:5000/api/records?size=1&page=3",
+        "self": "https://localhost:5000/api/mocks?size=1&page=2",
+        "prev": "https://localhost:5000/api/mocks?size=1&page=1",
+        "next": "https://localhost:5000/api/mocks?size=1&page=3",
     }
     # NOTE: This is done so that we only test for pagination links
     for key, url in expected_links.items():
@@ -139,12 +131,12 @@ def test_middle_search_result_has_next_and_prev_links(
 @pytest.mark.skip()
 def test_first_search_result_has_next_and_no_prev_link(
         client, three_indexed_records):
-    response = client.get("/records?size=1&page=1", headers=HEADERS)
+    response = client.get("/mocks?size=1&page=1", headers=HEADERS)
 
     response_links = response.json["links"]
     expected_links = {
-        "self": "https://localhost:5000/api/records?size=1&page=1",
-        "next": "https://localhost:5000/api/records?size=1&page=2",
+        "self": "https://localhost:5000/api/mocks?size=1&page=1",
+        "next": "https://localhost:5000/api/mocks?size=1&page=2",
     }
     # NOTE: This is done so that we only test for pagination links
     for key, url in expected_links.items():
@@ -158,13 +150,13 @@ def test_last_search_result_has_next_and_prev_links(
         client, three_indexed_records):
     # NOTE: We are replicating invenio-records-rest approach which could be
     #       discussed.
-    response = client.get("/records?size=1&page=3", headers=HEADERS)
+    response = client.get("/mocks?size=1&page=3", headers=HEADERS)
 
     response_links = response.json["links"]
     expected_links = {
-        "self": "https://localhost:5000/api/records?size=1&page=3",
-        "prev": "https://localhost:5000/api/records?size=1&page=2",
-        "next": "https://localhost:5000/api/records?size=1&page=4",
+        "self": "https://localhost:5000/api/mocks?size=1&page=3",
+        "prev": "https://localhost:5000/api/mocks?size=1&page=2",
+        "next": "https://localhost:5000/api/mocks?size=1&page=4",
     }
     # NOTE: This is done so that we only test for pagination links
     for key, url in expected_links.items():
@@ -179,17 +171,17 @@ def test_max_search_result_has_prev_and_no_next_link(
     max_results = DEFAULT_MAX_RESULTS
 
     response = client.get(
-        f"/records?size=1&page={max_results}",
+        f"/mocks?size=1&page={max_results}",
         headers=HEADERS
     )
 
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            f"https://localhost:5000/api/records?size=1&page={max_results}"
+            f"https://localhost:5000/api/mocks?size=1&page={max_results}"
         ),
         "prev": (
-            f"https://localhost:5000/api/records?size=1&page={max_results - 1}"
+            f"https://localhost:5000/api/mocks?size=1&page={max_results - 1}"
         ),
     }
     # NOTE: This is done so that we only test for pagination links
@@ -202,20 +194,20 @@ def test_max_search_result_has_prev_and_no_next_link(
 @pytest.mark.skip()
 def test_searchstring_is_preserved(client, three_indexed_records):
     response = client.get(
-        "/records?size=1&page=2&q=Romans+story",
+        "/mocks?size=1&page=2&q=Romans+story",
         headers=HEADERS
     )
 
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            "https://localhost:5000/api/records?size=1&page=2&q=Romans+story"
+            "https://localhost:5000/api/mocks?size=1&page=2&q=Romans+story"
         ),
         "prev": (
-            "https://localhost:5000/api/records?size=1&page=1&q=Romans+story"
+            "https://localhost:5000/api/mocks?size=1&page=1&q=Romans+story"
         ),
         "next": (
-            "https://localhost:5000/api/records?size=1&page=3&q=Romans+story"
+            "https://localhost:5000/api/mocks?size=1&page=3&q=Romans+story"
         ),
     }
     # NOTE: This is done so that we only test for pagination links

--- a/tests/resources/test_sorting.py
+++ b/tests/resources/test_sorting.py
@@ -13,37 +13,42 @@ import time
 from copy import deepcopy
 
 import pytest
+from flask_principal import Identity, Need, UserNeed
 from invenio_search import current_search
-
-from invenio_records_resources.services import RecordService
+from mock_module.service import Service
 
 HEADERS = {"content-type": "application/json", "accept": "application/json"}
 
 # 3 things to test
-# 0- search options are configurable (see conftest.py)
+# 0- search options are configurable (see mock_module)
 # 1- results are sorted
 # 2- links are generated
 
 
 @pytest.fixture("module")
-def three_indexed_records(app, input_service_data, identity_simple, es):
+def three_indexed_records(app, identity_simple, es):
     # NOTE: We make use of es fixture (and not es_clear) here because all tests
     #       assume 3 records have been indexed and NO tests in this module
     #       adds/deletes any.
-    record_service = RecordService()
-    search_class = record_service.config.search_cls
+    input_data = {
+        'metadata': {
+            'title': 'Test'
+        },
+    }
+    service = Service()
     title_parts = [
         "The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"
     ]
     title_parts_len = len(title_parts)
+
     units = []
     for i in range(3):
-        data = deepcopy(input_service_data)
-        data["title"] = " ".join(title_parts[:title_parts_len-3*i])
+        data = deepcopy(input_data)
+        data["metadata"]["title"] = " ".join(title_parts[:title_parts_len-3*i])
         time.sleep(0.01)
-        units += [record_service.create(identity_simple, data)]
+        units += [service.create(identity_simple, data)]
 
-    current_search.flush_and_refresh(search_class.Meta.index)
+    current_search.flush_and_refresh("*")
 
     return units
 
@@ -53,67 +58,33 @@ def three_indexed_records(app, input_service_data, identity_simple, es):
 #
 
 
-@pytest.mark.skip()
 def test_default_sorting_if_no_query(client, three_indexed_records):
     # NOTE: the default sorting in this case is by most recently created
-    response = client.get("/records", headers=HEADERS)
+    response = client.get("/mocks", headers=HEADERS)
 
     for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[2-i].id == hit["pid"]
+        assert three_indexed_records[2-i].id == hit["id"]
 
 
-@pytest.mark.skip()
 def test_default_sorting_if_query(client, three_indexed_records):
-    response = client.get("/records?q=over+the+lazy+dog", headers=HEADERS)
+    response = client.get("/mocks?q=over+the+lazy+dog", headers=HEADERS)
 
     for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[i].id == hit["pid"]
+        assert three_indexed_records[i].id == hit["id"]
 
 
-@pytest.mark.skip()
 def test_explicit_sort(client, three_indexed_records):
-    response = client.get("/records?sort=mostrecent", headers=HEADERS)
+    response = client.get("/mocks?sort=mostrecent", headers=HEADERS)
 
     for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[2-i].id == hit["pid"]
+        assert three_indexed_records[2-i].id == hit["id"]
 
 
-@pytest.mark.skip()
 def test_explicit_sort_reversed(client, three_indexed_records):
-    response = client.get("/records?sort=-mostrecent", headers=HEADERS)
+    response = client.get("/mocks?sort=-mostrecent", headers=HEADERS)
 
     for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[i].id == hit["pid"]
-
-
-@pytest.mark.skip()
-def test_explicit_sort_callable_search_options_field(
-        client, three_indexed_records):
-    # NOTE: callable_baz expects the equivalent of -mostrecent ordering
-    response = client.get("/records?sort=callable_baz", headers=HEADERS)
-
-    for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[i].id == hit["pid"]
-
-    response = client.get("/records?sort=-callable_baz", headers=HEADERS)
-
-    for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[2-i].id == hit["pid"]
-
-
-@pytest.mark.skip()
-def test_explicit_sort_dict_search_options_field(
-        client, three_indexed_records):
-    # NOTE: dict_baz expects the equivalent of -mostrecent ordering
-    response = client.get("/records?sort=dict_baz", headers=HEADERS)
-
-    for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[i].id == hit["pid"]
-
-    response = client.get("/records?sort=-dict_baz", headers=HEADERS)
-
-    for i, hit in enumerate(response.json['hits']['hits']):
-        assert three_indexed_records[2-i].id == hit["pid"]
+        assert three_indexed_records[i].id == hit["id"]
 
 
 #
@@ -121,19 +92,19 @@ def test_explicit_sort_dict_search_options_field(
 #
 
 @pytest.mark.skip()
-def test_sort_in_links_if_and_only_if_sort_in_url(
+def test_sort_in_links_no_matter_if_sort_in_url(
         client, three_indexed_records):
     response = client.get(
-        "/records?sort=mostrecent", headers=HEADERS
+        "/mocks?sort=mostrecent", headers=HEADERS
     )
 
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            "https://localhost:5000/api/records?size=25&page=1&sort=mostrecent"
+            "https://localhost:5000/mocks?page=1&size=25&sort=mostrecent"
         ),
         "next": (
-            "https://localhost:5000/api/records?size=25&page=2&sort=mostrecent"
+            "https://localhost:5000/mocks?page=2&size=25&sort=mostrecent"
         ),
     }
     # NOTE: This is done so that we only test for pagination links
@@ -141,16 +112,16 @@ def test_sort_in_links_if_and_only_if_sort_in_url(
         assert url == response_links[key]
 
     response = client.get(
-        "/records", headers=HEADERS
+        "/mocks", headers=HEADERS
     )
 
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            "https://localhost:5000/api/records?size=25&page=1"
+            "https://localhost:5000/mocks?page=1&size=25&sort=mostrecent"
         ),
         "next": (
-            "https://localhost:5000/api/records?size=25&page=2"
+            "https://localhost:5000/mocks?page=2&size=25&sort=mostrecent"
         ),
     }
     # NOTE: This is done so that we only test for pagination links
@@ -161,24 +132,27 @@ def test_sort_in_links_if_and_only_if_sort_in_url(
 @pytest.mark.skip()
 def test_searchstring_is_preserved(client, three_indexed_records):
     response = client.get(
-        "/records?q=Romans+story&sort=mostrecent",
+        "/mocks?q=Romans+story&sort=mostrecent",
         headers=HEADERS
     )
 
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            "https://localhost:5000/api/records?size=25&page=1&sort=mostrecent"
-            "&q=Romans+story"
+            "https://localhost:5000/mocks?page=1&q=Romans%20story&size=25"
+            "&sort=mostrecent"
         ),
         "next": (
-            "https://localhost:5000/api/records?size=25&page=2&sort=mostrecent"
-            "&q=Romans+story"
+            "https://localhost:5000/mocks?page=2&q=Romans%20story&size=25"
+            "&sort=mostrecent"
         ),
     }
     # NOTE: This is done so that we only test for pagination links
     for key, url in expected_links.items():
         assert url == response_links[key]
 
+
+# Q: Are '+' not dealt with appropriately when generating links?
+# Q: Is api/ prefix not dealt with appropriately when generating links?
 
 # Q: Should sort key be in output if key is undefined in backend?

--- a/tests/resources/test_sorting.py
+++ b/tests/resources/test_sorting.py
@@ -74,14 +74,14 @@ def test_default_sorting_if_query(client, three_indexed_records):
 
 
 def test_explicit_sort(client, three_indexed_records):
-    response = client.get("/mocks?sort=mostrecent", headers=HEADERS)
+    response = client.get("/mocks?sort=newest", headers=HEADERS)
 
     for i, hit in enumerate(response.json['hits']['hits']):
         assert three_indexed_records[2-i].id == hit["id"]
 
 
 def test_explicit_sort_reversed(client, three_indexed_records):
-    response = client.get("/mocks?sort=-mostrecent", headers=HEADERS)
+    response = client.get("/mocks?sort=oldest", headers=HEADERS)
 
     for i, hit in enumerate(response.json['hits']['hits']):
         assert three_indexed_records[i].id == hit["id"]
@@ -95,16 +95,16 @@ def test_explicit_sort_reversed(client, three_indexed_records):
 def test_sort_in_links_no_matter_if_sort_in_url(
         client, three_indexed_records):
     response = client.get(
-        "/mocks?sort=mostrecent", headers=HEADERS
+        "/mocks?sort=newest", headers=HEADERS
     )
 
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            "https://localhost:5000/mocks?page=1&size=25&sort=mostrecent"
+            "https://localhost:5000/mocks?page=1&size=25&sort=newest"
         ),
         "next": (
-            "https://localhost:5000/mocks?page=2&size=25&sort=mostrecent"
+            "https://localhost:5000/mocks?page=2&size=25&sort=newest"
         ),
     }
     # NOTE: This is done so that we only test for pagination links
@@ -118,10 +118,10 @@ def test_sort_in_links_no_matter_if_sort_in_url(
     response_links = response.json["links"]
     expected_links = {
         "self": (
-            "https://localhost:5000/mocks?page=1&size=25&sort=mostrecent"
+            "https://localhost:5000/mocks?page=1&size=25&sort=newest"
         ),
         "next": (
-            "https://localhost:5000/mocks?page=2&size=25&sort=mostrecent"
+            "https://localhost:5000/mocks?page=2&size=25&sort=newest"
         ),
     }
     # NOTE: This is done so that we only test for pagination links
@@ -132,7 +132,7 @@ def test_sort_in_links_no_matter_if_sort_in_url(
 @pytest.mark.skip()
 def test_searchstring_is_preserved(client, three_indexed_records):
     response = client.get(
-        "/mocks?q=Romans+story&sort=mostrecent",
+        "/mocks?q=Romans+story&sort=newest",
         headers=HEADERS
     )
 
@@ -140,11 +140,11 @@ def test_searchstring_is_preserved(client, three_indexed_records):
     expected_links = {
         "self": (
             "https://localhost:5000/mocks?page=1&q=Romans%20story&size=25"
-            "&sort=mostrecent"
+            "&sort=newest"
         ),
         "next": (
             "https://localhost:5000/mocks?page=2&q=Romans%20story&size=25"
-            "&sort=mostrecent"
+            "&sort=newest"
         ),
     }
     # NOTE: This is done so that we only test for pagination links

--- a/tests/services/test_service_pagination.py
+++ b/tests/services/test_service_pagination.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Service pagination tests.
+
+NOTE: See tests/resources/test_pagination for more comprehensive tests.
+      We test service-level aspects here.
+"""
+
+import pytest
+from invenio_search import current_search
+
+# from marshmallow import ValidationError
+
+
+#
+# Fixtures
+#
+@pytest.fixture(scope='module')
+def records(app, service, identity_simple):
+    """Input data (as coming from the view layer)."""
+    items = []
+    for idx in range(3):
+        data = {
+           'metadata': {
+                'title': f'00{idx}'
+            },
+        }
+        items.append(service.create(identity_simple, data))
+    current_search.flush_and_refresh('records-record-v1.0.0')
+    return items
+
+
+#
+# Tests
+#
+def test_default_pagination(service, identity_simple, records):
+    result = service.search(identity_simple).to_dict()
+
+    # NOTE: default pagination is enough to account for 3 records in 1 page
+    assert 3 == len(result["hits"]["hits"])
+
+
+def test_explicit_pagination(service, identity_simple, records):
+    result = service.search(
+        identity_simple, page=2, size=1, _max_result=3
+    ).to_dict()
+    assert 1 == len(result["hits"]["hits"])

--- a/tests/services/test_service_pagination.py
+++ b/tests/services/test_service_pagination.py
@@ -16,8 +16,6 @@ NOTE: See tests/resources/test_pagination for more comprehensive tests.
 import pytest
 from invenio_search import current_search
 
-# from marshmallow import ValidationError
-
 
 #
 # Fixtures
@@ -33,7 +31,9 @@ def records(app, service, identity_simple):
             },
         }
         items.append(service.create(identity_simple, data))
-    current_search.flush_and_refresh('records-record-v1.0.0')
+
+    service.record_cls.index.refresh()
+
     return items
 
 

--- a/tests/services/test_service_sort.py
+++ b/tests/services/test_service_sort.py
@@ -52,7 +52,7 @@ def test_default_no_query(service, identity_simple, records):
     """Default sorting without a query."""
     res = service.search(
         identity_simple, page=1, size=10, _max_results=100).to_dict()
-    assert sort_method(res) == 'mostrecent'
+    assert sort_method(res) == 'newest'
 
 
 def test_default_with_query(service, identity_simple, records):
@@ -65,9 +65,9 @@ def test_default_with_query(service, identity_simple, records):
 def test_user_selected_sort(service, identity_simple, records):
     """Chosen sort method."""
     res = service.search(
-        identity_simple, q='test', sort='mostrecent', page=1, size=10,
+        identity_simple, q='test', sort='newest', page=1, size=10,
         _max_results=100).to_dict()
-    assert sort_method(res) == 'mostrecent'
+    assert sort_method(res) == 'newest'
 
 
 def test_invalid_sort(service, identity_simple, records):
@@ -76,10 +76,10 @@ def test_invalid_sort(service, identity_simple, records):
     pytest.raises(ValidationError, service.search, identity_simple, sort="foo")
 
 
-def test_mostrecent(service, identity_simple, records):
+def test_newest(service, identity_simple, records):
     """Chosen sort method."""
     res = service.search(
-        identity_simple, sort='mostrecent', page=1, size=10,
+        identity_simple, sort='newest', page=1, size=10,
         _max_results=100).to_dict()
-    assert sort_method(res) == 'mostrecent'
+    assert sort_method(res) == 'newest'
     assert order(res) == [2, 1, 0]


### PR DESCRIPTION
- Service level defaults are used for pagination
- Pagination errors are dealt at the service level
- Link generation is pushed off to another issue.
- closes #56 