### PR TITLE
actions: remove compile_catalog from pypi publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,7 +18,7 @@ jobs:
           pip install setuptools wheel
       - name: Build package
         run: |
-          python setup.py compile_catalog sdist bdist_wheel
+          python setup.py sdist bdist_wheel
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.3.1
         with:


### PR DESCRIPTION
Fixes release https://github.com/inveniosoftware/invenio-records-resources/runs/1164534571

Missing invenio-records-resources v0.6.0 and v0.6.1