### PR TITLE
tests: resource level search with empty query

### DIFF
--- a/invenio_records_resources/services/records/params/querystr.py
+++ b/invenio_records_resources/services/records/params/querystr.py
@@ -31,7 +31,7 @@ class QueryStrParam(ParamInterpreter):
     def apply(self, identity, search, params):
         """Evaluate the query str on the search."""
         query_str = params.get('q')
-        if query_str is None:
+        if not query_str:
             return search
 
         try:

--- a/invenio_records_resources/version.py
+++ b/invenio_records_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_records_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/tests/resources/test_resource_faceting.py
+++ b/tests/resources/test_resource_faceting.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 import pytest
 from flask_principal import Identity, Need, UserNeed
 from invenio_search import current_search
+from mock_module.api import Record
 from mock_module.service import Service
 
 # 2 things to test
@@ -42,7 +43,7 @@ def three_indexed_records(app, identity_simple, es):
     _create({"title": "Record 2", "type": {"type": "A", "subtype": "AB"}})
     _create({"title": "Record 3", "type": {"type": "B"}})
 
-    current_search.flush_and_refresh("*")
+    Record.index.refresh()
 
 
 #

--- a/tests/resources/test_resource_pagination.py
+++ b/tests/resources/test_resource_pagination.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 
 import pytest
 from invenio_search import current_search
+from mock_module.api import Record
 from mock_module.service import Service
 
 # 2 things to test
@@ -36,7 +37,7 @@ def three_indexed_records(app, identity_simple, es):
         }
         service.create(identity_simple, data)
 
-    current_search.flush_and_refresh("*")
+    Record.index.refresh()
 
 
 @pytest.fixture(scope="module")

--- a/tests/resources/test_resource_sorting.py
+++ b/tests/resources/test_resource_sorting.py
@@ -15,6 +15,7 @@ from copy import deepcopy
 import pytest
 from flask_principal import Identity, Need, UserNeed
 from invenio_search import current_search
+from mock_module.api import Record
 from mock_module.service import Service
 
 # 3 things to test
@@ -46,7 +47,7 @@ def three_indexed_records(app, identity_simple, es):
         time.sleep(0.01)
         units += [service.create(identity_simple, data)]
 
-    current_search.flush_and_refresh("*")
+    Record.index.refresh()
 
     return units
 

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -13,6 +13,7 @@ import json
 
 import pytest
 from invenio_search import current_search, current_search_client
+from mock_module.api import Record
 
 
 @pytest.fixture()
@@ -42,7 +43,7 @@ def test_simple_flow(app, client, input_data, headers):
     assert res.json['metadata'] == input_data['metadata']
 
     # TODO: Should this be part of the service? we don't know the index easily
-    current_search.flush_and_refresh(idx)
+    Record.index.refresh()
 
     # Search it
     res = client.get('/mocks', query_string={'q': f'id:{id_}'}, headers=h)
@@ -62,7 +63,7 @@ def test_simple_flow(app, client, input_data, headers):
     assert res.status_code == 204
     assert res.get_data(as_text=True) == ''
 
-    current_search.flush_and_refresh(idx)
+    Record.index.refresh()
 
     # Try to get it again
     res = client.get(f'/mocks/{id_}', headers=h)
@@ -82,7 +83,7 @@ def test_search_empty_query_string(client, input_data, headers):
     assert res.status_code == 201
 
     # TODO: Should this be part of the service? we don't know the index easily
-    current_search.flush_and_refresh(idx)
+    Record.index.refresh()
 
     # Search it
     res = client.get('/mocks', headers=headers)

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -45,7 +45,7 @@ def test_simple_flow(app, client, input_data, headers):
     current_search.flush_and_refresh(idx)
 
     # Search it
-    res = client.get(f'/mocks', query_string={'q': f'id:{id_}'}, headers=h)
+    res = client.get('/mocks', query_string={'q': f'id:{id_}'}, headers=h)
     assert res.status_code == 200
     assert res.json['hits']['total'] == 1
     assert res.json['hits']['hits'][0]['metadata'] == input_data['metadata']
@@ -69,6 +69,29 @@ def test_simple_flow(app, client, input_data, headers):
     assert res.status_code == 410
 
     # Try to get search it again
-    res = client.get(f'/mocks', query_string={'q': f'id:{id_}'}, headers=h)
+    res = client.get('/mocks', query_string={'q': f'id:{id_}'}, headers=h)
     assert res.status_code == 200
     assert res.json['hits']['total'] == 0
+
+
+def test_search_empty_query_string(client, input_data, headers):
+    idx = 'records-record-v1.0.0'
+
+    # Create a record
+    res = client.post('/mocks', headers=headers, data=json.dumps(input_data))
+    assert res.status_code == 201
+
+    # TODO: Should this be part of the service? we don't know the index easily
+    current_search.flush_and_refresh(idx)
+
+    # Search it
+    res = client.get('/mocks', headers=headers)
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+    assert res.json['hits']['hits'][0]['metadata'] == input_data['metadata']
+
+    # Search it
+    res = client.get('/mocks', query_string={'q': ''}, headers=headers)
+    assert res.status_code == 200
+    assert res.json['hits']['total'] == 1
+    assert res.json['hits']['hits'][0]['metadata'] == input_data['metadata']


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/284

```
ipdb> params
{'q': ''}
> /Users/ppanero/Workspace/inveniosw/invenio-records-resources/invenio_records_resources/services/records/params/querystr.py(41)apply()
     35         if query_str is None:
     36             return search
     37
     38         try:
     39             parser_cls = self.config.search_query_parser_cls
     40             query = parser_cls(identity).parse(query_str)
---> 41             return search.query(query)
     42         except SyntaxError:
     43             # TOOD: raise a proper type of exception
     44             raise Exception("Failed to parse query.")

ipdb> query
QueryString(query='')
```

This makes the search *match empty*

**correct search**
```
{'query': {'bool': {'minimum_should_match': '0<1', 'filter': [{'match_all': {}}]}}, 'aggs': {'type': {'terms': {'field': 'metadata.type.type'}, 'aggs': {'subtype': {'terms': {'field': 'metadata.type.subtype'}}}}}, 'sort': [{'created': {'order': 'desc'}}], 'track_total_hits': True, 'from': 0, 'size': 25}
```

**what happens**
```
{'query': {'bool': {'minimum_should_match': '0<1', 'filter': [{'match_all': {}}], 'must': [{'query_string': {'query': ''}}]}}, 'aggs': {'type': {'terms': {'field': 'metadata.type.type'}, 'aggs': {'subtype': {'terms': {'field': 'metadata.type.subtype'}}}}}, 'sort': ['_score'], 'track_total_hits': True, 'from': 0, 'size': 25}
```

Note the *must* query.