### PR TITLE
sort: check if `q` param is empty

### DIFF
--- a/invenio_records_resources/services/records/params/sort.py
+++ b/invenio_records_resources/services/records/params/sort.py
@@ -17,7 +17,7 @@ class SortParam(ParamInterpreter):
     """Evaluate the 'sort' parameter."""
 
     def _default_sort(self, params, options):
-        if 'q' in params:
+        if params.get('q'):
             return self.config.search_sort_default
         else:
             return self.config.search_sort_default_no_query


### PR DESCRIPTION
React searchkit appends in the url the `?q` parameter even if is empty string. As a matter of fact, the search application has a configuration variable for choosing the default sort option on empty querystring. In the SortInterpreter we were just checking if the q is in the URL params without checking its value