### PR TITLE
service: add links to hits of a search result

### DIFF
--- a/invenio_records_resources/services/records/results.py
+++ b/invenio_records_resources/services/records/results.py
@@ -114,6 +114,8 @@ class RecordList(ServiceListResult):
     @property
     def hits(self):
         """Iterator over the hits."""
+        links = LinksFactory(host=_current_host, config=self._links_config)
+
         for hit in self._results:
             # Load dump
             record = self._service.record_cls.loads(hit.to_dict())
@@ -124,6 +126,8 @@ class RecordList(ServiceListResult):
                 record,
                 pid=record.pid,
                 record=record,
+                links_namespace="record",
+                links_factory=links
             )
 
             yield projection

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -40,3 +40,13 @@ def example_record(app, db):
     record = Record.create({}, metadata={'title': 'Test'})
     db.session.commit()
     return record
+
+
+@pytest.fixture(scope="function")
+def input_data():
+    """Input data (as coming from the view layer)."""
+    return {
+        'metadata': {
+            'title': 'Test',
+        },
+    }

--- a/tests/services/test_service.py
+++ b/tests/services/test_service.py
@@ -22,16 +22,6 @@ from marshmallow import ValidationError
 from mock_module.api import Record
 
 
-@pytest.fixture()
-def input_data():
-    """Input data (as coming from the view layer)."""
-    return {
-        'metadata': {
-            'title': 'Test',
-        },
-    }
-
-
 def test_simple_flow(app, service, identity_simple, input_data):
     """Create a record."""
     # Create an item


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-records-resources/issues/123

Tests added at service level with a mock of the links schema. If the resources define the proper schema links, they will be rendered (tested this manually and is correct).

**Question**: @lnielsen 

Should this task also include the addition of `delete`, `list` etc. links in for the record? Meaning changing `resources/records/schema_links.py` and implementing tests for them?