### PR TITLE
ci: update for docker-services-cli

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,20 +28,20 @@ jobs:
           include:
           - services: release
             SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
-            POSTGRESQL_VERSION: POSTGRESQL_12_LATEST
-            ES_VERSION: "ES_7_LATEST"
+            POSTGRESQL_VERSION: postgresql12
+            ES_VERSION: elasticsearch7
             EXTRAS: "all,postgresql,elasticsearch7"
             REQUIREMENTS_LEVEL: "pypi"
           - services: lowest
             SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
-            POSTGRESQL_VERSION: POSTGRESQL_9_LATEST
-            ES_VERSION: "ES_6_LATEST"
+            POSTGRESQL_VERSION: postgresql9
+            ES_VERSION: elasticsearch6
             EXTRAS: "all,postgresql,elasticsearch6"
             REQUIREMENTS_LEVEL: "min"
           - services: devel
             SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
-            POSTGRESQL_VERSION: POSTGRESQL_12_LATEST
-            ES_VERSION: "ES_7_LATEST"
+            POSTGRESQL_VERSION: postgresql12
+            ES_VERSION: elasticsearch7
             EXTRAS: "all,postgresql,elasticsearch7"
             REQUIREMENTS_LEVEL: "dev"
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
@@ -12,10 +12,16 @@ set -o errexit
 # Quit on unbound symbols
 set -o nounset
 
+# Always bring down docker services
+function cleanup() {
+    eval "$(docker-services-cli down --env)"
+}
+
+trap cleanup EXIT
+
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-docker-services-cli up es postgresql redis
+eval "$(docker-services-cli --verbose up --search ${ES_VERSION:-elasticsearch} --db ${POSTGRESQL_VERSION:-postgresql} --cache redis --env)"
 python -m pytest
 tests_exit_code=$?
-docker-services-cli down
 exit "$tests_exit_code"


### PR DESCRIPTION
- Merging this as it passes since it's an update to the CI.
- bumping to 0.9.1 to not have to alter the tag on master (don't want to alter master beyond adding releases) 
- :warning: docker-services-cli is managed by pytest-invenio
  (and new pytest-invenio has not been released yet)
  so developers need to explicitly `pip install --upgrade
  docker-services-cli` locally.
