### PR TITLE
ci: don't upgrade to docker-services-cli 0.3.0

### DIFF
--- a/invenio_records_resources/version.py
+++ b/invenio_records_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_records_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
@@ -12,10 +12,16 @@ set -o errexit
 # Quit on unbound symbols
 set -o nounset
 
+# Always bring down docker services
+function cleanup() {
+    docker-services-cli down
+}
+
+trap cleanup EXIT
+
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 docker-services-cli up es postgresql redis
 python -m pytest
 tests_exit_code=$?
-docker-services-cli down
 exit "$tests_exit_code"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ history = open("CHANGES.rst").read()
 tests_require = [
     "invenio-app>=1.3.0",
     "pytest-invenio>=1.4.0",
+    "docker-services-cli>=0.2.1,<0.3.0"
 ]
 
 # Should follow inveniosoftware/invenio versions


### PR DESCRIPTION
- Merging this as it passes since it's an update to the CI.
- bumping to 0.9.1 to not have to alter the tag on master (don't want to alter master beyond adding releases)
