### PR TITLE
errors: serialize schema errors uniformly

### DIFF
--- a/invenio_records_resources/errors.py
+++ b/invenio_records_resources/errors.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Common errors utilities."""
+
+
+def _iter_errors_dict(message_node, fieldpath=''):
+    """Recursively yield validation error dicts.
+
+    :params dict|list|value: Marshmallow error node (first is a dict)
+
+    For example:
+    {
+        'metadata': {
+            'creators': {
+                0: {
+                    'type': [
+                        "Invalid value. Choose one of
+                        ['organizational', 'personal']."
+                    ]
+                }
+            }
+        }
+    }
+    :fieldpath string: path to current message_node
+    :returns dict:
+
+    Example validation error dicts returned:
+    {
+        "field": "metadata.creators.0.type",
+        "messages": [
+            "Invalid value. Choose one of ['organizational', 'personal']."
+        ]
+    }
+    """
+    if isinstance(message_node, dict):
+        for field, child in message_node.items():
+            yield from _iter_errors_dict(
+                child,
+                fieldpath=(f"{fieldpath}." if fieldpath else '') + f"{field}"
+            )
+    elif isinstance(message_node, list):
+        # If the node is a list, it's a leaf node of messages
+        yield {
+            "field": f"{fieldpath}",
+            "messages": message_node
+        }
+    else:
+        # leaf node - always wrap in a list
+        yield {
+            "field": f"{fieldpath}",
+            "messages": [message_node]
+        }
+
+
+def validation_error_to_list_errors(exception):
+    """Convert exception to a list of error dicts.
+
+    Each error dict is shaped as follows:
+
+        {
+            "field": "dotted.path.to.field",
+            "messages": ["errors msg1", ... "error msgN"]
+        }
+
+    :params ValidationError exception: Marshmallow load errror
+    :returns: list<dict>
+    """
+    errors = exception.normalized_messages()
+    return list(_iter_errors_dict(errors))

--- a/invenio_records_resources/resources/actions/config.py
+++ b/invenio_records_resources/resources/actions/config.py
@@ -8,7 +8,11 @@
 
 """File resource configuration."""
 
+from flask_resources.errors import create_errormap_handler
 from flask_resources.resources import ResourceConfig
+from marshmallow.exceptions import ValidationError
+
+from ..errors import HTTPJSONValidationException
 
 
 class ActionResourceConfig(ResourceConfig):
@@ -21,4 +25,10 @@ class ActionResourceConfig(ResourceConfig):
         'read': {},
         'update': {},
         'delete': {}
+    }
+
+    error_map = {
+        ValidationError: create_errormap_handler(
+            lambda e: HTTPJSONValidationException(e)
+        ),
     }

--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
-#
+# Copyright (C) 2020 Northwestern University
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.

--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Common Errors handling for Resources."""
+
+from flask_resources.errors import HTTPJSONException
+
+from ..errors import validation_error_to_list_errors
+
+
+class HTTPJSONValidationException(HTTPJSONException):
+    """HTTP exception serializing to JSON and reflecting Marshmallow errors."""
+
+    description = "A validation error occurred."
+
+    def __init__(self, exception):
+        """Constructor."""
+        super().__init__(
+            code=400,
+            errors=validation_error_to_list_errors(exception)
+        )

--- a/invenio_records_resources/resources/records/config.py
+++ b/invenio_records_resources/resources/records/config.py
@@ -15,9 +15,11 @@ from flask_resources.resources import ResourceConfig
 from flask_resources.serializers import JSONSerializer
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError, \
     PIDRedirectedError, PIDUnregistered
+from marshmallow.exceptions import ValidationError
 
 from ...services.errors import PermissionDeniedError, \
     QuerystringValidationError, RevisionIdMismatchError
+from ..errors import HTTPJSONValidationException
 from .errors import create_pid_redirected_error_handler
 from .response import RecordResponse
 from .schemas_header import RequestHeadersSchema
@@ -51,6 +53,9 @@ class RecordResourceConfig(ResourceConfig):
     }
 
     error_map = {
+        ValidationError: create_errormap_handler(
+            lambda e: HTTPJSONValidationException(e)
+        ),
         RevisionIdMismatchError: create_errormap_handler(
             lambda e: HTTPJSONException(
                 code=412,

--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -12,6 +12,8 @@ from marshmallow import EXCLUDE, INCLUDE, Schema, ValidationError, fields, \
     validate
 from marshmallow_utils.fields import Links
 
+from invenio_records_resources.errors import validation_error_to_list_errors
+
 
 #
 # The default record schema
@@ -97,7 +99,7 @@ class MarshmallowServiceSchema(ServiceSchema):
             if raise_errors:
                 raise
             valid_data = e.valid_data
-            errors = e.messages
+            errors = validation_error_to_list_errors(e)
         return valid_data, errors
 
     def dump(self, identity, data, schema_args=None, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "flask-resources>=0.3.3,<1.0.0",
+    "flask-resources>=0.4.0,<1.0.0",
     "invenio-accounts>=1.4.3",
     "invenio-base>=1.2.3",
     "invenio-files-rest>=1.2.0",
@@ -106,7 +106,8 @@ setup(
             "invenio_records_resources:InvenioRecordsResources",
         ],
         "invenio_i18n.translations": [
-            "messages = invenio_records_resources", ],
+            "messages = invenio_records_resources",
+        ],
     },
     extras_require=extras_require,
     install_requires=install_requires,

--- a/tests/services/test_service__create.py
+++ b/tests/services/test_service__create.py
@@ -18,7 +18,8 @@ def test_default(app, service, identity_simple, input_data):
     assert item.data["metadata"]
 
 
-def test_allow_missing_required(app, service, identity_simple):
+def test_create_but_report_missing_required_field(
+        app, service, identity_simple):
     """Create a record without required fields."""
     input_data = {
         'metadata': {}
@@ -31,10 +32,14 @@ def test_allow_missing_required(app, service, identity_simple):
 
     assert item.id
     assert item_dict["metadata"] == {}
-    assert item_dict["errors"]["metadata"]["title"]
+    errors = [{
+        "field": "metadata.title",
+        "messages": ["Missing data for required field."]
+    }]
+    assert errors == item_dict["errors"]
 
 
-def test_allow_missing_required_incorrect_field(app, service, identity_simple):
+def test_create_but_report_incorrect_field(app, service, identity_simple):
     input_data = {
         'metadata': {
             'title': 10,
@@ -48,4 +53,8 @@ def test_allow_missing_required_incorrect_field(app, service, identity_simple):
 
     assert item.id
     assert item_dict["metadata"] == {}
-    assert item_dict["errors"]["metadata"]["title"]
+    errors = [{
+        "field": "metadata.title",
+        "messages": ["Not a valid string."]
+    }]
+    assert errors == item_dict["errors"]


### PR DESCRIPTION
Now all schema validation errors should lead to

```
'errors': [{'field': ..., 'message': ...}, ...]
```

entry in final json.

requires: https://github.com/inveniosoftware/flask-resources/pull/89
