### PR TITLE
systemfields: fix files field json serialization

### DIFF
--- a/invenio_records_resources/records/systemfields/files.py
+++ b/invenio_records_resources/records/systemfields/files.py
@@ -383,7 +383,7 @@ class FilesField(SystemField):
                 record=instance,
                 file_cls=self.file_cls,
                 enabled=data.get('enabled', self._enabled),
-                order=data.get('order'),
+                order=data.get('order', []),
                 default_preview=data.get('default_preview'),
                 entries=data.get('entries', {}) if self._store else None,
             )
@@ -395,9 +395,11 @@ class FilesField(SystemField):
         """Set the object."""
         data = {
             'enabled': files.enabled,
-            'order': files.order,
-            'default_preview': files.default_preview,
         }
+        if files.order:
+            data['order'] = files.order
+        if files.default_preview:
+            data['default_preview'] = files.default_preview
 
         if self._store and files.enabled:
             data['entries'] = {}

--- a/invenio_records_resources/version.py
+++ b/invenio_records_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_records_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/tests/records/test_systemfield_files.py
+++ b/tests/records/test_systemfield_files.py
@@ -48,8 +48,8 @@ def test_record_files_creation(base_app, db, location):
 
     assert record['files']
     assert record['files']['enabled'] is True
-    assert record['files']['default_preview'] is None
-    assert record['files']['order'] == []
+    assert 'default_preview' not in record['files']
+    assert 'order' not in record['files']
     assert record['files']['entries'] == {}
 
 


### PR DESCRIPTION
* Fixes issue with "order" and "default_preview" keys being stored even
  if they are none or empty.