### PR TITLE
permissions: enforce files permissions

### DIFF
--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -58,7 +58,7 @@ class FileServiceMixin:
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "read", record=record)
+        self.require_permission(identity, "read_files", record=record)
         return self.file_result_list(
             self,
             identity,
@@ -140,6 +140,7 @@ class FileServiceMixin:
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
+        self.require_permission(identity, "read_files", record=record)
         return self.file_result_item(
             self,
             identity,
@@ -250,6 +251,7 @@ class FileServiceMixin:
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
+        self.require_permission(identity, "read_files", record=record)
         # TODO Signal here or in resource?
         # file_downloaded.send(file_obj)
         return self.file_result_item(


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/401
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/406
- enforces all file permissions 
- required for https://github.com/inveniosoftware/invenio-rdm-records/pull/402 (tests really reside)
 - fixes some file deletion code that was broken