### PR TITLE
services: refresh index on delete

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -331,6 +331,6 @@ class RecordService(Service):
         db.session.commit()
 
         if self.indexer:
-            self.indexer.delete(record)
+            self.indexer.delete(record, refresh=True)
 
         return True


### PR DESCRIPTION
* Refreshes the index when deleting an record, as the user is often
  redirect straight after to a search results which often will include
  the just deleted record.