### PR TITLE
run-tests: forward supplied options and arguments to pytest

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,16 @@
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+# Usage:
+#   ./run-tests.sh [pytest options and args...]
+#
+# Note: the DB, SEARCH and CACHE services to use are determined by corresponding environment
+#       variables if they are set -- otherwise, the following defaults are used:
+#       DB=postgresql, SEARCH=elasticsearch and CACHE=redis
+#
+# Example for using mysql instead of postgresql:
+#    DB=mysql CACHE=redis ./run-tests.sh
+
 # Quit on errors
 set -o errexit
 
@@ -22,7 +32,7 @@ trap cleanup EXIT
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --env)"
-python -m pytest
+python -m pytest $@
 tests_exit_code=$?
 python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 exit "$tests_exit_code"


### PR DESCRIPTION
closes inveniosoftware/invenio-app-rdm#675
pretty much the same as inveniosoftware/invenio-app-rdm/pull/690