### PR TITLE
services: specify record kwarg for schema.dump in ResultItem

### DIFF
--- a/invenio_records_resources/services/records/results.py
+++ b/invenio_records_resources/services/records/results.py
@@ -57,6 +57,7 @@ class RecordItem(ServiceItemResult):
         self._data = self._service.schema.dump(
             self._identity,
             self._record,
+            record=self._record,
             links_namespace="record",
             links_factory=links,
         )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 
 # Should follow inveniosoftware/invenio versions
 invenio_search_version = '>=1.4.1,<2.0.0'
-invenio_db_version = '>=1.0.8,<2.0.0'
+invenio_db_version = '>=1.0.9,<2.0.0'
 
 extras_require = {
     "docs": ["Sphinx>=2.4,<3"],


### PR DESCRIPTION
closes inveniosoftware/invenio-rdm-records#439
in `ResultItem.data`, the `record` keyword argument was missing from the call to `self._service.schema.dump()`, causing the `record` argument in the permission generators to be set to `None`