### PR TITLE
resources/services: config that can enable/disable file upload

### DIFF
--- a/invenio_records_resources/resources/files/config.py
+++ b/invenio_records_resources/resources/files/config.py
@@ -16,6 +16,7 @@ class FileResourceConfig(ResourceConfig):
     """File resource config."""
 
     # Blueprint configuration
+    allow_upload = True
     blueprint_name = None
     url_prefix = "/records/<pid_value>"
     routes = {

--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -51,18 +51,22 @@ class FileResource(ErrorHandlersMixin, Resource):
     def create_url_rules(self):
         """Routing for the views."""
         routes = self.config.routes
-        return [
+        url_rules = [
             route("GET", routes["list"], self.search),
-            route("POST", routes["list"], self.create),
-            route("PUT", routes["list"], self.update_all),
-            route("DELETE", routes["list"], self.delete_all),
             route("GET", routes["item"], self.read),
-            route("PUT", routes["item"], self.update),
-            route("DELETE", routes["item"], self.delete),
-            route("POST", routes["item-commit"], self.create_commit),
             route("GET", routes["item-content"], self.read_content),
-            route("PUT", routes["item-content"], self.update_content),
         ]
+        if self.config.allow_upload:
+            url_rules += [
+                route("POST", routes["list"], self.create),
+                route("PUT", routes["list"], self.update_all),
+                route("DELETE", routes["list"], self.delete_all),
+                route("PUT", routes["item"], self.update),
+                route("DELETE", routes["item"], self.delete),
+                route("POST", routes["item-commit"], self.create_commit),
+                route("PUT", routes["item-content"], self.update_content),
+            ]
+        return url_rules
 
     @request_view_args
     @response_handler(many=True)

--- a/invenio_records_resources/services/files/config.py
+++ b/invenio_records_resources/services/files/config.py
@@ -24,6 +24,8 @@ class FileServiceConfig(ServiceConfig):
 
     record_cls = None
 
+    permission_action_prefix = ""
+
     file_result_item_cls = FileItem
     file_result_list_cls = FileList
 
@@ -36,5 +38,4 @@ class FileServiceConfig(ServiceConfig):
     file_links_item = {
         "self": FileLink("{+api}/records/{id}/files/{key}"),
         "content": FileLink("{+api}/records/{id}/files/{key}/content"),
-        "commit": FileLink("{+api}/records/{id}/files/{key}/commit"),
     }

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -75,7 +75,8 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "create_files", record=record)
+        action = self.config.permission_action_prefix + "create_files"
+        self.require_permission(identity, action, record=record)
         # TODO: Load via marshmallow schema?
         results = []
         for file_metadata in data:
@@ -99,7 +100,8 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "update_files", record=record)
+        action = self.config.permission_action_prefix + "update_files"
+        self.require_permission(identity, action, record=record)
 
         # TODO: Maybe there's a better programmatic API to apply these?
         # e.g. record.files.update(...)
@@ -158,7 +160,8 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "create_files", record=record)
+        action = self.config.permission_action_prefix + "create_files"
+        self.require_permission(identity, action, record=record)
         file_obj = ObjectVersion.get(record.bucket.id, file_key)
         if not file_obj:
             raise Exception(f'File with key {file_key} not uploaded yet.')
@@ -178,7 +181,8 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "delete_files", record=record)
+        action = self.config.permission_action_prefix + "delete_files"
+        self.require_permission(identity, action, record=record)
         deleted_file = record.files.delete(file_key)
         # We also commit the record in case the file was the `default_preview`
         record.commit()
@@ -196,7 +200,8 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "delete_files", record=record)
+        action = self.config.permission_action_prefix + "delete_files"
+        self.require_permission(identity, action, record=record)
         # NOTE: We have to separate the gathering of the keys from their
         #       deletion because of how record.files is implemented.
         file_keys = [fk for fk in record.files]
@@ -219,7 +224,8 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, "create_files", record=record)
+        action = self.config.permission_action_prefix + "create_files"
+        self.require_permission(identity, action, record=record)
         rf = record.files.get(file_key)
 
         # TODO: raise an appropriate exception

--- a/tests/mock_module/resource.py
+++ b/tests/mock_module/resource.py
@@ -26,3 +26,11 @@ class CustomFileResourceConfig(FileResourceConfig):
 
     blueprint_name = "mocks_files"
     url_prefix = "/mocks/<pid_value>"
+
+
+class CustomDisabledUploadFileResourceConfig(FileResourceConfig):
+    """Custom file resource configuration."""
+
+    allow_upload = False
+    blueprint_name = "mocks_disabled_files_upload"
+    url_prefix = "/mocks_disabled_files_upload/<pid_value>"


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/498
- Added a  `allow_upload` config value to FileResource to enable/disable file upload
- Added a `permission_action_prefix` config value to FileService to allow to define a prefix for differentiated permissions in permission policy
- Throw more specific exceptions for file errors in FilesManager to prevent returning 500 server error e.g when same file is uploaded second time