### PR TITLE
files: enable/disable files via record body

### DIFF
--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -103,10 +103,6 @@ class FileService(Service):
         action = self.config.permission_action_prefix + "update_files"
         self.require_permission(identity, action, record=record)
 
-        # TODO: Maybe there's a better programmatic API to apply these?
-        # e.g. record.files.update(...)
-        if data.get('enabled') is not None:
-            record.files.enabled = data['enabled']
         if record.files.enabled:
             if 'default_preview' in data:
                 record.files.default_preview = data['default_preview']

--- a/invenio_records_resources/services/records/components.py
+++ b/invenio_records_resources/services/records/components.py
@@ -86,15 +86,14 @@ class FilesOptionsComponent(ServiceComponent):
 
     def _validate_files_enabled(self, record, enabled):
         """Validate files enabled."""
-        if not enabled:
-            if record.files.values():
-                raise ValidationError(
-                    _("You must first delete all files to set the record to "
-                      "be metadata-only."),
-                    field_name="files.enabled"
-                )
+        if not enabled and record.files.values():
+            raise ValidationError(
+                _("You must first delete all files to set the record to "
+                  "be metadata-only."),
+                field_name="files.enabled"
+            )
 
-    def assign_files_enabled(self, identity, enabled, record=None, **kwargs):
+    def assign_files_enabled(self, enabled, record=None, **kwargs):
         """Assign files enabled.
 
         This is a public interface so that it can be reused elsewhere
@@ -107,10 +106,10 @@ class FilesOptionsComponent(ServiceComponent):
         """Inject parsed files options in the record."""
         # presence is guaranteed by schema
         enabled = data["files"]["enabled"]
-        self.assign_files_enabled(identity, enabled, record, **kwargs)
+        record.files.enabled = enabled
 
     def update(self, identity, data=None, record=None, **kwargs):
         """Inject parsed files options in the record."""
         # presence is guaranteed by schema
         enabled = data["files"]["enabled"]
-        self.assign_files_enabled(identity, enabled, record, **kwargs)
+        self.assign_files_enabled(enabled, record, **kwargs)

--- a/invenio_records_resources/services/records/config.py
+++ b/invenio_records_resources/services/records/config.py
@@ -21,7 +21,6 @@ from .links import RecordLink, pagination_links
 from .params import FacetsParam, PaginationParam, QueryParser, QueryStrParam, \
     SortParam
 from .results import RecordItem, RecordList
-from .schema import RecordSchema
 
 
 class SearchOptions:
@@ -78,7 +77,7 @@ class RecordServiceConfig(ServiceConfig):
     search = SearchOptions
 
     # Service schema
-    schema = RecordSchema
+    schema = None  # Needs to be defined on concrete record service config
 
     links_item = {
         "self": RecordLink("{+api}/records/{id}"),

--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -10,8 +10,7 @@
 
 from datetime import timezone
 
-from marshmallow import INCLUDE, Schema, ValidationError, fields, pre_load, \
-    validate
+from marshmallow import Schema, ValidationError, fields, pre_load, validate
 from marshmallow_utils.fields import Links, TZDateTime
 
 from invenio_records_resources.errors import validation_error_to_list_errors
@@ -20,17 +19,6 @@ from invenio_records_resources.errors import validation_error_to_list_errors
 #
 # The default record schema
 #
-class MetadataSchema(Schema):
-    """Basic metadata schema class."""
-
-    class Meta:
-        """Meta class to accept unknown fields."""
-
-        unknown = INCLUDE
-
-    title = fields.Str(required=True, validate=validate.Length(min=3))
-
-
 class BaseRecordSchema(Schema):
     """Schema for records v1 in JSON."""
 
@@ -53,10 +41,40 @@ class BaseRecordSchema(Schema):
         return data
 
 
+class TypeSchema(Schema):
+    """Nested type schema used for faceting tests."""
+
+    type = fields.Str()
+    subtype = fields.Str()
+
+
+class MetadataSchema(Schema):
+    """Basic metadata schema class."""
+
+    title = fields.Str(required=True, validate=validate.Length(min=3))
+    type = fields.Nested(TypeSchema)
+
+
 class RecordSchema(BaseRecordSchema):
-    """Schema for records v1 in JSON."""
+    """Schema for records v1 in JSON.
+
+    NOTE: In practice, this schema would not be used. BaseRecordSchema is
+          recommended.
+    """
 
     metadata = fields.Nested(MetadataSchema)
+
+
+class FilesOptionsSchema(Schema):
+    """Basic files options schema class."""
+
+    enabled = fields.Bool(missing=True)
+
+
+class RecordWithFilesSchema(RecordSchema):
+    """Schema for records with files."""
+
+    files = fields.Nested(FilesOptionsSchema, required=True)
 
 
 class ServiceSchemaWrapper:

--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -10,7 +10,7 @@
 
 from datetime import timezone
 
-from marshmallow import Schema, ValidationError, fields, pre_load, validate
+from marshmallow import Schema, ValidationError, fields, pre_load
 from marshmallow_utils.fields import Links, TZDateTime
 
 from invenio_records_resources.errors import validation_error_to_list_errors
@@ -41,42 +41,6 @@ class BaseRecordSchema(Schema):
         return data
 
 
-class TypeSchema(Schema):
-    """Nested type schema used for faceting tests."""
-
-    type = fields.Str()
-    subtype = fields.Str()
-
-
-class MetadataSchema(Schema):
-    """Basic metadata schema class."""
-
-    title = fields.Str(required=True, validate=validate.Length(min=3))
-    type = fields.Nested(TypeSchema)
-
-
-class RecordSchema(BaseRecordSchema):
-    """Schema for records v1 in JSON.
-
-    NOTE: In practice, this schema would not be used. BaseRecordSchema is
-          recommended.
-    """
-
-    metadata = fields.Nested(MetadataSchema)
-
-
-class FilesOptionsSchema(Schema):
-    """Basic files options schema class."""
-
-    enabled = fields.Bool(missing=True)
-
-
-class RecordWithFilesSchema(RecordSchema):
-    """Schema for records with files."""
-
-    files = fields.Nested(FilesOptionsSchema, required=True)
-
-
 class ServiceSchemaWrapper:
     """Schema wrapper that enhances load/dump of wrapped schema.
 
@@ -86,7 +50,7 @@ class ServiceSchemaWrapper:
             * injects the field permission check in the context
     """
 
-    def __init__(self, service, schema=RecordSchema):
+    def __init__(self, service, schema):
         """Constructor."""
         self.schema = schema
         # TODO: Change constructor to accept a permission_policy_cls directly

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ fixtures are available.
 import pytest
 from celery.messaging import establish_connection
 from invenio_app.factory import create_api as _create_api
-from invenio_files_rest.models import Location
 from kombu.compat import Consumer
 from mock_module.config import MockFileServiceConfig
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ from celery.messaging import establish_connection
 from invenio_app.factory import create_api as _create_api
 from invenio_files_rest.models import Location
 from kombu.compat import Consumer
+from mock_module.config import MockFileServiceConfig
+
+from invenio_records_resources.services import FileService
 
 pytest_plugins = ("celery.contrib.pytest", )
 
@@ -69,3 +72,9 @@ def consumer(app, queue):
             exchange=app.config['INDEXER_MQ_EXCHANGE'].name,
             routing_key=app.config['INDEXER_MQ_ROUTING_KEY'],
         )
+
+
+@pytest.fixture(scope="module")
+def file_service():
+    """File service shared fixture."""
+    return FileService(MockFileServiceConfig)

--- a/tests/factories/test_factory.py
+++ b/tests/factories/test_factory.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 """Factory tests."""
+
 import pytest
+from mock_module.schemas import RecordSchema
 from sqlalchemy.exc import InvalidRequestError
-from uritemplate import URITemplate
 
 from invenio_records_resources.factories.factory import RecordTypeFactory
 from invenio_records_resources.services import RecordServiceConfig, \
     SearchOptions
 from invenio_records_resources.services.records.components import \
     ServiceComponent
-from invenio_records_resources.services.records.schema import RecordSchema
 from invenio_records_resources.services.records.search import terms_filter
 
 

--- a/tests/factories/test_service.py
+++ b/tests/factories/test_service.py
@@ -1,8 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 from invenio_records_permissions import RecordPermissionPolicy
 from invenio_records_permissions.generators import AnyUser
+from mock_module.schemas import RecordSchema
 
 from invenio_records_resources.factories.factory import RecordTypeFactory
-from invenio_records_resources.services.records.schema import RecordSchema
 
 
 def test_simple_flow(app, identity_simple, db):

--- a/tests/mock_module/config.py
+++ b/tests/mock_module/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -12,10 +12,13 @@
 from invenio_records_resources.services import FileServiceConfig, \
     RecordServiceConfig, SearchOptions
 from invenio_records_resources.services.files.links import FileLink
+from invenio_records_resources.services.records.components import \
+    FilesOptionsComponent
 from invenio_records_resources.services.records.config import SearchOptions
 from invenio_records_resources.services.records.links import RecordLink, \
     pagination_links
-from invenio_records_resources.services.records.schema import RecordSchema
+from invenio_records_resources.services.records.schema import RecordSchema, \
+    RecordWithFilesSchema
 from invenio_records_resources.services.records.search import terms_filter
 
 from .api import Record, RecordWithFile
@@ -66,6 +69,8 @@ class ServiceWithFilesConfig(ServiceConfig):
     """Config for service with files support."""
 
     record_cls = RecordWithFile
+    components = RecordServiceConfig.components + [FilesOptionsComponent]
+    schema = RecordWithFilesSchema
 
 
 class MockFileServiceConfig(FileServiceConfig):

--- a/tests/mock_module/config.py
+++ b/tests/mock_module/config.py
@@ -17,12 +17,11 @@ from invenio_records_resources.services.records.components import \
 from invenio_records_resources.services.records.config import SearchOptions
 from invenio_records_resources.services.records.links import RecordLink, \
     pagination_links
-from invenio_records_resources.services.records.schema import RecordSchema, \
-    RecordWithFilesSchema
 from invenio_records_resources.services.records.search import terms_filter
 
 from .api import Record, RecordWithFile
 from .permissions import PermissionPolicy
+from .schemas import RecordSchema, RecordWithFilesSchema
 
 
 class MockSearchOptions(SearchOptions):

--- a/tests/mock_module/schemas.py
+++ b/tests/mock_module/schemas.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Mock module schemas."""
+
+from marshmallow import Schema, fields, validate
+
+from invenio_records_resources.services.records.schema import BaseRecordSchema
+
+
+class TypeSchema(Schema):
+    """Nested type schema used for faceting tests."""
+
+    type = fields.Str()
+    subtype = fields.Str()
+
+
+class MetadataSchema(Schema):
+    """Basic metadata schema class."""
+
+    title = fields.Str(required=True, validate=validate.Length(min=3))
+    type = fields.Nested(TypeSchema)
+
+
+class RecordSchema(BaseRecordSchema):
+    """Test RecordSchema."""
+
+    metadata = fields.Nested(MetadataSchema)
+
+
+class FilesOptionsSchema(Schema):
+    """Basic files options schema class."""
+
+    enabled = fields.Bool(missing=True)
+
+
+class RecordWithFilesSchema(RecordSchema):
+    """Schema for records with files."""
+
+    files = fields.Nested(FilesOptionsSchema, required=True)

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -15,8 +15,8 @@ fixtures are available.
 
 import pytest
 from flask_principal import Identity, Need, UserNeed
+from mock_module.config import ServiceConfig
 from mock_module.resource import CustomRecordResourceConfig
-from mock_module.service import ServiceConfig
 
 from invenio_records_resources.resources import RecordResource
 from invenio_records_resources.services import RecordService
@@ -56,4 +56,14 @@ def headers():
     return {
         'content-type': 'application/json',
         'accept': 'application/json',
+    }
+
+
+@pytest.fixture()
+def input_data():
+    """Input data (as coming from the view layer)."""
+    return {
+        'metadata': {
+            'title': 'Test'
+        },
     }

--- a/tests/resources/test_resource_faceting.py
+++ b/tests/resources/test_resource_faceting.py
@@ -12,7 +12,7 @@
 
 import pytest
 from mock_module.api import Record
-from mock_module.service import ServiceConfig
+from mock_module.config import ServiceConfig
 
 from invenio_records_resources.services import RecordService
 

--- a/tests/resources/test_resource_links.py
+++ b/tests/resources/test_resource_links.py
@@ -1,25 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 """Service tests."""
-
-import pytest
-
-
-@pytest.fixture()
-def input_data():
-    """Input data (as coming from the view layer)."""
-    return {
-        'metadata': {
-            'title': 'Test'
-        },
-    }
 
 
 def assert_expected_links(pid_value, links, site_hostname="127.0.0.1:5000"):

--- a/tests/resources/test_resource_pagination.py
+++ b/tests/resources/test_resource_pagination.py
@@ -11,7 +11,7 @@
 
 import pytest
 from mock_module.api import Record
-from mock_module.service import ServiceConfig
+from mock_module.config import ServiceConfig
 
 from invenio_records_resources.services import RecordService
 

--- a/tests/resources/test_resource_sorting.py
+++ b/tests/resources/test_resource_sorting.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 
 import pytest
 from mock_module.api import Record
-from mock_module.service import ServiceConfig
+from mock_module.config import ServiceConfig
 
 from invenio_records_resources.services import RecordService
 

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -11,19 +11,7 @@
 
 import json
 
-import pytest
-from invenio_search import current_search, current_search_client
 from mock_module.api import Record
-
-
-@pytest.fixture()
-def input_data():
-    """Input data (as coming from the view layer)."""
-    return {
-        'metadata': {
-            'title': 'Test'
-        },
-    }
 
 
 def test_simple_flow(app, client, input_data, headers):

--- a/tests/services/__init__.py
+++ b/tests/services/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Services test module."""

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -12,7 +12,6 @@
 See https://pytest-invenio.readthedocs.io/ for documentation on which test
 fixtures are available.
 """
-from uuid import uuid4
 
 import pytest
 from flask_principal import Identity, Need, UserNeed

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 import pytest
 from flask_principal import Identity, Need, UserNeed
 from mock_module.api import Record, RecordWithFile
-from mock_module.service import ServiceConfig
+from mock_module.config import ServiceConfig
 
 from invenio_records_resources.services import RecordService
 

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -96,17 +96,6 @@ def test_file_flow(
     assert result.files == {}
 
 
-def _add_file_to_record(recid, file_id, identity, service):
-    # Initialize file saving
-    result = service.init_file(recid, identity, data={})
-    assert result.files
-    result = service.save_file(
-        recid, file_id, identity, BytesIO(b'test file content'))
-    assert result.files.get(file_id)
-
-    return result
-
-
 @pytest.mark.skip()
 def test_read_not_commited_file(service, example_record, identity_simple):
     recid = example_record.id

--- a/tests/services/files_utils.py
+++ b/tests/services/files_utils.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Files utils for testing."""
+
+from io import BytesIO
+
+
+def add_file_to_record(file_service, recid, file_id, identity):
+    """Add a file to the record."""
+    file_service.init_files(recid, identity, data=[{'key': file_id}])
+    file_service.set_file_content(
+        recid, file_id, identity, BytesIO(b'test file content')
+    )
+    result = file_service.commit_file(recid, file_id, identity)
+    return result

--- a/tests/services/test_files_options.py
+++ b/tests/services/test_files_options.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Test setting files options on the record."""
+
+import pytest
+from marshmallow import ValidationError
+from mock_module.config import ServiceWithFilesConfig
+
+from invenio_records_resources.services import RecordService
+
+from .files_utils import add_file_to_record
+
+
+@pytest.fixture(scope='module')
+def service(appctx):
+    """Service with files instance."""
+    return RecordService(ServiceWithFilesConfig)
+
+
+def test_enable_files(app, location, service, identity_simple, input_data):
+    input_data["files"] = {
+        "enabled": True
+    }
+
+    item = service.create(identity_simple, input_data)
+
+    item_dict = item.to_dict()
+    assert {"enabled": True} == item_dict["files"]
+    assert item._record.files.enabled is True
+
+
+def test_disable_files(app, location, service, identity_simple, input_data):
+    input_data["files"] = {
+        "enabled": False
+    }
+
+    item = service.create(identity_simple, input_data)
+
+    item_dict = item.to_dict()
+    assert {"enabled": False} == item_dict["files"]
+    assert item._record.files.enabled is False
+
+
+def test_disable_files_when_files_already_present_should_error(
+        app, location, service, file_service, identity_simple, input_data):
+    # NOTE: The reverse is not True for practical UX reasons.
+    #       We don't want to precede a file upload with a record upload for
+    #       every toggle of the metadata-only checkbox.
+    input_data["files"] = {
+        "enabled": True
+    }
+    item = service.create(identity_simple, input_data)
+    add_file_to_record(file_service, item.id, 'file.txt', identity_simple)
+    input_data["files"] = {
+        "enabled": False
+    }
+
+    with pytest.raises(ValidationError):
+        item = service.update(item.id, identity_simple, input_data)


### PR DESCRIPTION
- part of closing #225
  * defines component to assign `files.enabled`
  * ended up having to do the majority of the changes here because file addition is defined in this package
- renames `tests/mock_module/service.py` -> `tests/mock_module/config.py`
- removes `unknown = INCLUDE` in keeping with previous work (see https://github.com/inveniosoftware/invenio-rdm-records/issues/496)
- moves some fixtures up the hierarchy so they can be reused 
