### PR TITLE
files: hard remove object versions

### DIFF
--- a/invenio_records_resources/records/systemfields/files/manager.py
+++ b/invenio_records_resources/records/systemfields/files/manager.py
@@ -140,8 +140,7 @@ class FilesManager(MutableMapping):
         # Delete the entire row
         rf.delete(force=True)
         if ov:
-            # TODO: Should we also remove the FileInstance? Configurable?
-            ObjectVersion.delete(ov.bucket, key)
+            rf.object_version.remove()
         del self._entries[key]
 
         # Unset the default preview if the file is removed

--- a/tests/records/test_systemfield_files.py
+++ b/tests/records/test_systemfield_files.py
@@ -118,7 +118,7 @@ def test_record_files_operations(base_app, db, location):
 
     assert models.FileRecordMetadata.query.count() == 0
     assert FileInstance.query.count() == 1
-    assert ObjectVersion.query.count() == 2  # original + delete marker
+    assert ObjectVersion.query.count() == 0
     assert Bucket.query.count() == 1
     assert len(record.files) == 0
     assert 'test.pdf' not in record.files
@@ -155,7 +155,7 @@ def test_record_files_clear(base_app, db, location):
 
     assert models.FileRecordMetadata.query.count() == 0
     assert FileInstance.query.count() == 2
-    assert ObjectVersion.query.count() == 4  # 2 original + 2 delete markers
+    assert ObjectVersion.query.count() == 0
     assert Bucket.query.count() == 1
     assert len(record.files) == 0
     assert 'f1.pdf' not in record.files


### PR DESCRIPTION
* Fixes an issues where object versions was soft-deleted instead of
  hard-deleted, thus leaving the files behind.