### PR TITLE
files: add method to return a file stream

### DIFF
--- a/invenio_records_resources/records/api.py
+++ b/invenio_records_resources/records/api.py
@@ -82,6 +82,13 @@ class FileRecord(RecordBase, SystemFieldsMixin):
         finally:
             fp.close()
 
+    def get_stream(self, mode):
+        """Get a file stream for a given file record.
+
+        It is up to the caller to close the steam.
+        """
+        return self.object_version.file.storage().open(mode)
+
     @property
     def record(self):
         """Get the file's record."""

--- a/invenio_records_resources/services/files/results.py
+++ b/invenio_records_resources/services/files/results.py
@@ -50,8 +50,15 @@ class FileItem(RecordItem):
             restricted=restricted, as_attachment=as_attachment)
 
     def open_stream(self, mode):
-        """Return a file stream."""
+        """Return a file stream context manager."""
         return self._file.open_stream(mode)
+
+    def get_stream(self, mode):
+        """Return a file stream.
+
+        It is up to the caller to close the steam.
+        """
+        return self._file.get_stream(mode)
 
 
 class FileList(ServiceListResult):


### PR DESCRIPTION
Why is this needed?

- Flask-IIIF is expecting a byte stream:
    - Which will be obtained (not read), [here](https://github.com/inveniosoftware/flask-iiif/blob/0f48cb3b5ba43170eca7aa0d2ff14205c8d08497/flask_iiif/restful.py#L76)
    - And passed to Pillow for opening [here](https://github.com/inveniosoftware/flask-iiif/blob/0f48cb3b5ba43170eca7aa0d2ff14205c8d08497/flask_iiif/api.py#L580)
    - **Important issue** It seems nobody `close()`s the stream....

**In order not to change the API**, and therefore have to change Flask-IIIF, we must return a byte stream. That means, that we cannot use the `open_stream` context manager (because it would close the stream when `return`ing). It will be generated by the `image_opener_handler` created in [`invenio-rdm-records`](https://github.com/inveniosoftware/invenio-rdm-records/blob/191af0a7c79f92413d335c428d695768a71082c2/invenio_rdm_records/handlers.py#L30).  

*Other options that were considered*
- Using the context manager at `invenio-rdm-records.handlers:image_opener` level and returning a deep copy of the stream (could turn into veeeery constly).
- Change Flask-IIIF to use the context manager and make `invenio-rdm-records.handlers:image_opener` return one. This would be problematic for the *pdf/documents with pager*, where we would need to: open the file, get the first page, and dynamically create a context manager for that file. Or have to return types stream and context manager... Not nice in any of the cases... 


closes https://github.com/inveniosoftware/invenio-iiif/issues/38 (⚠️ IT DOES NOT, but I wanted to link it in the board and I cannot if crossrepo unleses `closes`).