### PR TITLE
services: bump record read_all max_records to 150

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -334,7 +334,7 @@ class RecordService(Service):
         return self.result_list(self, identity, results)
 
     def read_all(
-        self, identity, fields, max_records=100, **kwargs
+        self, identity, fields, max_records=150, **kwargs
     ):
         """Search for records matching the querystring."""
         es_query = Q("match_all")


### PR DESCRIPTION
We have 100+ resource types at NU so that limit constantly crashes selection
of certain resource types. We have other vocabularies that have the potential
to grow past 100 as well.

Tracking every use of read_all is unfeasible so making the change here.

Until we figure out a better way to address these instance-specific
scaling concerns, I am bumping the default max_records so that
this works for us and probably others.
