### PR TITLE
factory: add support for record relations

### DIFF
--- a/invenio_records_resources/factories/factory.py
+++ b/invenio_records_resources/factories/factory.py
@@ -50,6 +50,7 @@ class RecordTypeFactory(object):
         schema_version="1.0.0",
         endpoint_route=None,
         record_dumper=None,
+        record_relations=None,
         schema_path=None,
         index_name=None,
         search_options=None,
@@ -74,6 +75,7 @@ class RecordTypeFactory(object):
         # record class attributes
         self.schema_version = schema_version
         self.record_dumper = record_dumper
+        self.record_relations = record_relations
         self.schema_path = self._build_schema_path(schema_path)
         self.index_name = self._build_index_name(index_name)
 
@@ -145,6 +147,10 @@ class RecordTypeFactory(object):
             "pid": pid_field,
             "dumper": self.record_dumper or ElasticsearchDumper(),
         }
+
+        if self.record_relations:
+            record_class_attributes["relations"] = self.record_relations
+
         self.record_cls = type(
             self.record_type_name, (Record,), record_class_attributes
         )

--- a/invenio_records_resources/version.py
+++ b/invenio_records_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_records_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-records-resources/issues/289

## Notes for the merger
- It does not break compatibility.
- Before merging we should make a version bump so it does not go into the previous LTS, however it can go in the next independently of the ORCiD integration due to the point below.