### PR TITLE
links: use record's public id i.e. record.id

### DIFF
--- a/invenio_records_resources/services/records/links.py
+++ b/invenio_records_resources/services/records/links.py
@@ -18,7 +18,7 @@ class RecordLink(Link):
     def vars(record, vars):
         """Variables for the URI template."""
         vars.update({
-            "id": record.pid.pid_value
+            "id": record.id
         })
 
 


### PR DESCRIPTION
This fixes some issue experienced generating links when the `record` doesn't use a `pid` system field to generate its public id. (e.g. in requests / request events)