### PR TITLE
service: add "unit of work" for atomic operations

### DIFF
--- a/invenio_records_resources/services/base/components.py
+++ b/invenio_records_resources/services/base/components.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Base class for all service components."""
+
+
+class BaseServiceComponent:
+    """Base service component."""
+
+    def __init__(self, service, *args, **kwargs):
+        """Initialize the base service component."""
+        self.service = service
+        self._uow = None
+
+    @property
+    def uow(self):
+        """Get the Unit of Work manager."""
+        if self._uow is None:
+            # Warn about wrong usage
+            raise RuntimeError(
+                "Method is not running in a unit of work context.")
+        return self._uow
+
+    @uow.setter
+    def uow(self, value):
+        """Set the Unit of Work manager."""
+        if value is not None and self._uow is not None:
+            # Don't set it twice.
+            raise RuntimeError("Unit of work already set on component.")
+        self._uow = value

--- a/invenio_records_resources/services/base/service.py
+++ b/invenio_records_resources/services/base/service.py
@@ -60,10 +60,17 @@ class Service:
 
     def run_components(self, action, *args, **kwargs):
         """Run components for a given action."""
-        # Run post commit components
+        uow = kwargs.pop("uow", None)
+
         for component in self.components:
             if hasattr(component, action):
+                # Done like this to avoid breaking API changes.
+                # uow should eventually be passed directly to the component
+                # so service/component method signature matches.
+                if uow is not None:
+                    component.uow = uow
                 getattr(component, action)(*args, **kwargs)
+                component.uow = None
 
     #
     # Units of transaction methods (creation...)

--- a/invenio_records_resources/services/files/components/base.py
+++ b/invenio_records_resources/services/files/components/base.py
@@ -8,13 +8,11 @@
 
 """Files service components."""
 
+from ...base.components import BaseServiceComponent
 
-class FileServiceComponent:
+
+class FileServiceComponent(BaseServiceComponent):
     """Base service component."""
-
-    def __init__(self, service, *args, **kwargs):
-        """Constructor."""
-        self.service = service
 
     def list_files(self, id_, identity, record):
         """List files handler."""
@@ -24,16 +22,8 @@ class FileServiceComponent:
         """Init files handler."""
         pass
 
-    def post_init_files(self, id_, identity, record, data):
-        """Post init files handler."""
-        pass
-
     def update_file_metadata(self, id_, file_key, identity, record, data):
         """Update file metadata handler."""
-        pass
-
-    def post_update_file_metadata(self, id_, file_key, identity, record, data):
-        """Post update file metadata handler."""
         pass
 
     def read_file_metadata(self, id_, file_key, identity, record):
@@ -48,34 +38,17 @@ class FileServiceComponent:
         """Commit file handler."""
         pass
 
-    def post_commit_file(self, id_, file_key, identity, record):
-        """Post commit file handler."""
-        pass
-
     def delete_file(self, id_, file_key, identity, record, deleted_file):
         """Delete file handler."""
-        pass
-
-    def post_delete_file(self, id_, file_key, identity, record, deleted_file):
-        """Post delete file handler."""
         pass
 
     def delete_all_file(self, id_, file_key, identity, record, results):
         """Delete all files handler."""
         pass
 
-    def post_delete_all_file(self, id_, file_key, identity, record, results):
-        """Post delete all files handler."""
-        pass
-
     def set_file_content(
             self, id_, file_key, identity, stream, content_length, record):
         """Set file content handler."""
-        pass
-
-    def post_set_file_content(
-            self, id_, file_key, identity, stream, content_length, record):
-        """Post set file content handler."""
         pass
 
     def get_file_content(self, id_, file_key, identity, record):

--- a/invenio_records_resources/services/records/components.py
+++ b/invenio_records_resources/services/records/components.py
@@ -13,13 +13,11 @@ from flask_babelex import gettext as _
 from invenio_files_rest.errors import InvalidKeyError
 from marshmallow import ValidationError
 
+from ..base.components import BaseServiceComponent
 
-class ServiceComponent:
+
+class ServiceComponent(BaseServiceComponent):
     """Base service component."""
-
-    def __init__(self, service, *args, **kwargs):
-        """Constructor."""
-        self.service = service
 
     def create(self, identity, **kwargs):
         """Create handler."""

--- a/invenio_records_resources/services/uow.py
+++ b/invenio_records_resources/services/uow.py
@@ -1,0 +1,298 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Unit of work.
+
+Used to group multiple service operations into a single atomic unit. The Unit
+of Work maintains a list of operations and coordinates the commit, indexing and
+task execution.
+
+Note, this is NOT a clean implementation of the UoW design pattern. The
+main purpose of the Unit of Work in Invenio is to coordinate when the database
+transaction commit is called, and ensure tasks that have to run after the
+transcation are executed (such as indexing and running celery tasks).
+
+This ensures that we can group multiple service calls into a single database
+transaction and perform the necessary indexing/task execution afterwards.
+
+**When to use?**
+
+You should use the unit of work instead of running an explicit
+``db.session.commit()`` or ``db.session.rollback()`` in the code. Basically
+any function where you would normally have called a ``db.session.commit()``
+should be changed to something like:
+
+.. code-block:: python
+
+    from invenio_records_resources.services.uow import \
+        RecordCommitOp, unit_of_work,
+
+    @unit_of_work()
+    def create(self, ... , uow=None):
+        # ...
+        uow.register(RecordCommitOp(record, indexer=self.indexer))
+        # ...
+        # Do not use `db.session.commit()` in service.
+
+Any private method that need to run operations after the database transaction
+commit should take the unit of work as input:
+
+.. code-block:: python
+
+    def _reindex_something(uow, ...):
+        # Index after transaction (no record commit)
+        uow.register(RecordIndexOp(record))
+
+    def _send_a_task(uow, ...):
+        # Run a celery task after the database transaction commit.
+        uow.register(TaskOp(my_celery_task, myarg, ... ))
+
+
+**When not to use?**
+
+If you're not changing the database state there's no need to use the unit of
+work. Examples include:
+
+- Reading a record
+- Search for records
+- Reindex all records - because there's no database transaction involved, and
+  the method is also not intended to be grouped together with multiple other
+  state changing service calls there's no need to use the unit of work.
+
+**How to group multiple service calls?**
+
+In order to group multiple service calls into one atomic operation you can use
+the following pattern:
+
+.. code-block:: python
+
+    from invenio_records_resources.services.uow import UnitOfWork
+
+    with UnitOfWork() as uow:
+        # Be careful to always inject "uow" to the service. If not, the
+        # service will create its own unit of work and commit.
+        service.communities.add(..., uow=uow)
+        service.publish(... , uow=uow)
+        uow.commit()
+
+If you're not grouping multiple service calls, then simply just call the
+service method (and it will commit automatically):
+
+.. code-block:: python
+
+    service.publish(...)
+
+**Writing your own operation?**
+
+You can write your own unit of work operation by subclassing the operation
+class and implementing the desired methods:
+
+.. code-block:: python
+
+    from invenio_records_resources.services.uow import Operation
+
+    class BulkIndexOp(Operation):
+        def on_commit(self, uow):
+            # ... executed after the database transaction commit ...
+"""
+
+
+from functools import wraps
+
+from invenio_db import db
+
+
+#
+# Unit of work operations
+#
+class Operation:
+    """Base class for unit of work operations."""
+
+    def on_register(self, uow):
+        """Called upon operation registration."""
+        pass
+
+    def on_commit(self, uow):
+        """Called in the commit phase (after the transaction is committed)."""
+        pass
+
+    def on_post_commit(self, uow):
+        """Called right after the commit phase."""
+        pass
+
+    def on_rollback(self, uow):
+        """Called in the rollback phase (after the transaction rollback)."""
+        pass
+
+    def on_post_rollback(self, uow):
+        """Called right after the rollback phase."""
+        pass
+
+
+class RecordCommitOp(Operation):
+    """Record commit operation with indexing."""
+
+    def __init__(self, record, indexer=None, index_refresh=False):
+        """Initialize the record commit operation."""
+        self._record = record
+        self._indexer = indexer
+        self._index_refresh = index_refresh
+
+    def on_register(self, uow):
+        """Commit record (will flush to the database)."""
+        self._record.commit()
+
+    def on_commit(self, uow):
+        """Run the operation."""
+        if self._indexer is not None:
+            arguments = {"refresh": True} if self._index_refresh else {}
+            self._indexer.index(self._record, arguments=arguments)
+
+
+class RecordIndexOp(RecordCommitOp):
+    """Record indexing operation."""
+
+    def on_register(self, uow):
+        """Overwrite method to not commit."""
+        pass
+
+
+class RecordDeleteOp(Operation):
+    """Record removal operation."""
+
+    def __init__(self, record, indexer=None, force=False, index_refresh=False):
+        """Initialize the record delete operation."""
+        self._record = record
+        self._indexer = indexer
+        self._force = force
+        self._index_refresh = index_refresh
+
+    def on_register(self, uow):
+        """Soft/hard delete record."""
+        self._record.delete(force=self._force)
+
+    def on_commit(self, uow):
+        """Delete from index."""
+        if self._indexer is not None:
+            self._indexer.delete(self._record, refresh=self._index_refresh)
+
+
+class TaskOp(Operation):
+    """A celery task operation.
+
+    Celery tasks are always execute after the entire commit phase.
+    """
+
+    def __init__(self, celery_task, *args, **kwargs):
+        """Initialize the task operation."""
+        self._celery_task = celery_task
+        self._args = args
+        self._kwargs = kwargs
+
+    def on_post_commit(self, uow):
+        """Run the post task operation."""
+        self._celery_task.delay(*self._args, **self._kwargs)
+
+
+#
+# Unit of work context manager
+#
+class UnitOfWork:
+    """Unit of work context manager.
+
+    Note, the unit of work does not currently take duplication of work into
+    account. Thus, you can e.g. add two record commit operations of the same
+    record which will then index the record twice, even though only one time
+    is needed.
+    """
+
+    def __init__(self, session=None):
+        """Initialize unit of work context."""
+        self._session = session or db.session
+        self._operations = []
+        self._dirty = False
+
+    def __enter__(self):
+        """Entering the context."""
+        return self
+
+    def __exit__(self, exc_type, *args):
+        """Rollback on exception."""
+        if exc_type is not None:
+            self.rollback()
+            self._mark_dirty()
+
+    @property
+    def session(self):
+        """The SQLAlchemy database session associated with this UoW."""
+        return self._session
+
+    def _mark_dirty(self):
+        """Mark the unit of work as dirty."""
+        if self._dirty:
+            raise RuntimeError(
+                "The unit of work is already committed or rolledback.")
+        self._dirty = True
+
+    def commit(self):
+        """Commit the unit of work."""
+        self._mark_dirty()
+        self.session.commit()
+        # Run commit operations
+        for op in self._operations:
+            op.on_commit(self)
+        # Run post commit operations
+        for op in self._operations:
+            op.on_post_commit(self)
+
+    def rollback(self):
+        """Rollback the database session."""
+        self.session.rollback()
+        # Run rollback operations
+        for op in self._operations:
+            op.on_rollback(self)
+        # Run post rollback operations
+        for op in self._operations:
+            op.on_post_rollback(self)
+
+    def register(self, op):
+        """Register an operation."""
+        # Run on register
+        op.on_register(self)
+        # Append to list of operations.
+        self._operations.append(op)
+
+
+def unit_of_work(**kwargs):
+    """Decorator to auto-inject a unit of work if not provided.
+
+    If no unit of work is provided, this decorator will create a new unit of
+    work and commit it after the function has been executed.
+
+    .. code-block:: python
+
+        @unit_of_work()
+        def aservice_method(self, ...., uow=None):
+            # ...
+            uow.register(...)
+
+    """
+    def decorator(f):
+        @wraps(f)
+        def inner(self, *args, **kwargs):
+            if 'uow' not in kwargs:
+                # Migration path - start a UoW and commit
+                with UnitOfWork(db.session) as uow:
+                    kwargs['uow'] = uow
+                    res = f(self, *args, **kwargs)
+                    uow.commit()
+                    return res
+            else:
+                return f(self, *args, **kwargs)
+        return inner
+    return decorator

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ invenio_search_version = '>=1.4.2,<2.0.0'
 invenio_db_version = '>=1.0.9,<2.0.0'
 
 extras_require = {
-    "docs": ["Sphinx>=2.4,<3"],
+    "docs": ["Sphinx==4.2.0"],
     # Elasticsearch version
     'elasticsearch6': [
         'invenio-search[elasticsearch6]{}'.format(invenio_search_version),


### PR DESCRIPTION
* Adds a new Unit of Work context manager used to allow atomic
  operations over multiple service calls.

* Keeps API as backwards compatible as possible.