### PR TITLE
services: order methods consistently with identity first

### DIFF
--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -72,8 +72,8 @@ class FileResource(ErrorHandlersMixin, Resource):
     def search(self):
         """List files."""
         files = self.service.list_files(
-            resource_requestctx.view_args["pid_value"],
             g.identity,
+            resource_requestctx.view_args["pid_value"],
         )
         return files.to_dict(), 200
 
@@ -81,8 +81,8 @@ class FileResource(ErrorHandlersMixin, Resource):
     def delete_all(self):
         """Delete all files."""
         self.service.delete_all_files(
-            resource_requestctx.view_args["pid_value"],
             g.identity,
+            resource_requestctx.view_args["pid_value"],
         )
 
         return "", 204
@@ -93,8 +93,8 @@ class FileResource(ErrorHandlersMixin, Resource):
     def create(self):
         """Initialize an upload on a record."""
         item = self.service.init_files(
-            resource_requestctx.view_args["pid_value"],
             g.identity,
+            resource_requestctx.view_args["pid_value"],
             resource_requestctx.data or [],
         )
         return item.to_dict(), 201
@@ -104,9 +104,9 @@ class FileResource(ErrorHandlersMixin, Resource):
     def read(self):
         """Read a single file."""
         item = self.service.read_file_metadata(
+            g.identity,
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
-            g.identity,
         )
         return item.to_dict(), 200
 
@@ -116,9 +116,9 @@ class FileResource(ErrorHandlersMixin, Resource):
     def update(self):
         """Update the metadata a single file."""
         item = self.service.update_file_metadata(
+            g.identity,
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
-            g.identity,
             resource_requestctx.data or {},
         )
         return item.to_dict(), 200
@@ -127,9 +127,9 @@ class FileResource(ErrorHandlersMixin, Resource):
     def delete(self):
         """Delete a file."""
         self.service.delete_file(
+            g.identity,
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
-            g.identity,
         )
 
         return "", 204
@@ -139,9 +139,9 @@ class FileResource(ErrorHandlersMixin, Resource):
     def create_commit(self):
         """Commit a file."""
         item = self.service.commit_file(
+            g.identity,
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
-            g.identity,
         )
         return item.to_dict(), 200
 
@@ -149,9 +149,9 @@ class FileResource(ErrorHandlersMixin, Resource):
     def read_content(self):
         """Read file content."""
         item = self.service.get_file_content(
+            g.identity,
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
-            g.identity,
         )
         return item.send_file(), 200
 
@@ -162,9 +162,9 @@ class FileResource(ErrorHandlersMixin, Resource):
         """Upload file content."""
         # TODO: Parse in `resource_requestctx`
         item = self.service.set_file_content(
+            g.identity,
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
-            g.identity,
             resource_requestctx.data["request_stream"],
             content_length=resource_requestctx.data["request_content_length"],
         )

--- a/invenio_records_resources/resources/records/resource.py
+++ b/invenio_records_resources/resources/records/resource.py
@@ -95,8 +95,8 @@ class RecordResource(ErrorHandlersMixin, Resource):
     def read(self):
         """Read an item."""
         item = self.service.read(
-            resource_requestctx.view_args["pid_value"],
             g.identity,
+            resource_requestctx.view_args["pid_value"],
         )
         return item.to_dict(), 200
 
@@ -107,8 +107,8 @@ class RecordResource(ErrorHandlersMixin, Resource):
     def update(self):
         """Update an item."""
         item = self.service.update(
-            resource_requestctx.view_args["pid_value"],
             g.identity,
+            resource_requestctx.view_args["pid_value"],
             resource_requestctx.data,
             revision_id=resource_requestctx.headers.get("if_match"),
         )
@@ -119,8 +119,8 @@ class RecordResource(ErrorHandlersMixin, Resource):
     def delete(self):
         """Delete an item."""
         self.service.delete(
-            resource_requestctx.view_args["pid_value"],
             g.identity,
+            resource_requestctx.view_args["pid_value"],
             revision_id=resource_requestctx.headers.get("if_match"),
         )
         return "", 204

--- a/invenio_records_resources/services/files/components/base.py
+++ b/invenio_records_resources/services/files/components/base.py
@@ -14,31 +14,31 @@ from ...base.components import BaseServiceComponent
 class FileServiceComponent(BaseServiceComponent):
     """Base service component."""
 
-    def list_files(self, id_, identity, record):
+    def list_files(self, identity, id_, record):
         """List files handler."""
         pass
 
-    def init_files(self, id_, identity, record, data):
+    def init_files(self, identity, id_, record, data):
         """Init files handler."""
         pass
 
-    def update_file_metadata(self, id_, file_key, identity, record, data):
+    def update_file_metadata(self, identity, id_, file_key, record, data):
         """Update file metadata handler."""
         pass
 
-    def read_file_metadata(self, id_, file_key, identity, record):
+    def read_file_metadata(self, identity, id_, file_key, record):
         """Read file metadata."""
         pass
 
     def extract_file_metadata(
-            self, id_, file_key, identity, record, file_record):
+            self, identity, id_, file_key, record, file_record):
         """Extract file metadata handler."""
 
-    def commit_file(self, id_, file_key, identity, record):
+    def commit_file(self, identity, id_, file_key, record):
         """Commit file handler."""
         pass
 
-    def delete_file(self, id_, file_key, identity, record, deleted_file):
+    def delete_file(self, identity, id_, file_key, record, deleted_file):
         """Delete file handler."""
         pass
 
@@ -47,10 +47,10 @@ class FileServiceComponent(BaseServiceComponent):
         pass
 
     def set_file_content(
-            self, id_, file_key, identity, stream, content_length, record):
+            self, identity, id_, file_key, stream, content_length, record):
         """Set file content handler."""
         pass
 
-    def get_file_content(self, id_, file_key, identity, record):
+    def get_file_content(self, identity, id_, file_key, record):
         """Get file content handler."""
         pass

--- a/invenio_records_resources/services/files/components/content.py
+++ b/invenio_records_resources/services/files/components/content.py
@@ -19,7 +19,7 @@ class FileContentComponent(FileServiceComponent):
     """File metadata service component."""
 
     def set_file_content(
-            self, id, file_key, identity, stream, content_length, record):
+            self, identity, id, file_key, stream, content_length, record):
         """Set file content handler."""
         # Check if associated file record exists and is not already committed.
         # TODO: raise an appropriate exception
@@ -50,7 +50,7 @@ class FileContentComponent(FileServiceComponent):
             obj.set_contents(
                 stream, size=content_length, size_limit=size_limit)
 
-    def get_file_content(self, id, file_key, identity, record):
+    def get_file_content(self, identity, id, file_key, record):
         """Get file content handler."""
         # TODO Signal here or in resource?
         # file_downloaded.send(file_obj)

--- a/invenio_records_resources/services/files/components/metadata.py
+++ b/invenio_records_resources/services/files/components/metadata.py
@@ -19,7 +19,7 @@ from .base import FileServiceComponent
 class FileMetadataComponent(FileServiceComponent):
     """File metadata service component."""
 
-    def init_files(self, id, identity, record, data):
+    def init_files(self, identity, id, record, data):
         """Init files handler."""
         schema = InitFileSchema(many=True)
         validated_data = schema.load(data)
@@ -27,12 +27,12 @@ class FileMetadataComponent(FileServiceComponent):
             temporary_obj = deepcopy(file_metadata)
             record.files.create(temporary_obj.pop('key'), data=temporary_obj)
 
-    def update_file_metadata(self, id, file_key, identity, record, data):
+    def update_file_metadata(self, identity, id, file_key, record, data):
         """Update file metadata handler."""
         record.files.update(file_key, data=data)
 
     # TODO: `commit_file` might vary based on your storage backend (e.g. S3)
-    def commit_file(self, id, file_key, identity, record):
+    def commit_file(self, identity, id, file_key, record):
         """Commit file handler."""
         # TODO: Add other checks here (e.g. verify checksum, S3 upload)
         file_obj = ObjectVersion.get(record.bucket.id, file_key)

--- a/invenio_records_resources/services/files/components/processor.py
+++ b/invenio_records_resources/services/files/components/processor.py
@@ -18,7 +18,7 @@ from .base import FileServiceComponent
 class FileProcessorComponent(FileServiceComponent):
     """File metadata service component."""
 
-    def commit_file(self, id, file_key, identity, record):
+    def commit_file(self, identity, id, file_key, record):
         """Post commit file handler."""
         # Ship off a task to extract file metadata once a file is committed.
         service_id = current_service_registry.get_service_id(self.service)
@@ -26,7 +26,7 @@ class FileProcessorComponent(FileServiceComponent):
             TaskOp(extract_file_metadata, service_id, id, file_key))
 
     def extract_file_metadata(
-            self, id_, file_key, identity, record, file_record):
+            self, identity, id_, file_key, record, file_record):
         """Extract and save file metadata for a given file."""
         if file_record.metadata is None:
             file_record.metadata = {}

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -63,7 +63,7 @@ class FileService(Service):
     #
     # High-level API
     #
-    def list_files(self, id_, identity):
+    def list_files(self, identity, id_):
         """List the files of a record."""
         record = self.get_record(id_, identity, "read_files")
 
@@ -79,11 +79,11 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def init_files(self, id_, identity, data, uow=None):
+    def init_files(self, identity, id_, data, uow=None):
         """Initialize the file upload for the record."""
         record = self.get_record(id_, identity, "create_files")
 
-        self.run_components("init_files", id_, identity, record, data, uow=uow)
+        self.run_components("init_files", identity, id_, record, data, uow=uow)
 
         return self.file_result_list(
             self,
@@ -95,12 +95,12 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def update_file_metadata(self, id_, file_key, identity, data, uow=None):
+    def update_file_metadata(self, identity, id_, file_key, data, uow=None):
         """Update the metadata of a file."""
         record = self.get_record(id_, identity, "create_files")
 
         self.run_components(
-            "update_file_metadata", id_, file_key, identity, record, data,
+            "update_file_metadata", identity, id_, file_key, record, data,
             uow=uow)
 
         return self.file_result_item(
@@ -111,12 +111,12 @@ class FileService(Service):
             links_tpl=self.file_links_item_tpl(id_),
         )
 
-    def read_file_metadata(self, id_, file_key, identity):
+    def read_file_metadata(self, identity, id_, file_key):
         """Read the metadata of a file."""
         record = self.get_record(id_, identity, "read_files")
 
         self.run_components(
-            "read_file_metadata", id_, file_key, identity, record)
+            "read_file_metadata", identity, id_, file_key, record)
 
         return self.file_result_item(
             self,
@@ -127,13 +127,13 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def extract_file_metadata(self, id_, file_key, identity, uow=None):
+    def extract_file_metadata(self, identity, id_, file_key, uow=None):
         """Extract metadata from a file and update the file metadata file."""
         record = self.get_record(id_, identity, "create_files")
         file_record = record.files[file_key]
 
         self.run_components(
-            "extract_file_metadata", id_, file_key, identity, record,
+            "extract_file_metadata", identity, id_, file_key, record,
             file_record, uow=uow)
 
         uow.register(RecordCommitOp(file_record))
@@ -147,12 +147,12 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def commit_file(self, id_, file_key, identity, uow=None):
+    def commit_file(self, identity, id_, file_key, uow=None):
         """Commit a file upload."""
         record = self.get_record(id_, identity, "create_files")
 
         self.run_components(
-            "commit_file", id_, file_key, identity, record, uow=uow)
+            "commit_file", identity, id_, file_key, record, uow=uow)
 
         return self.file_result_item(
             self,
@@ -163,13 +163,13 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def delete_file(self, id_, file_key, identity, uow=None):
+    def delete_file(self, identity, id_, file_key, uow=None):
         """Delete a single file."""
         record = self.get_record(id_, identity, "delete_files")
         deleted_file = record.files.delete(file_key)
 
         self.run_components(
-            "delete_file", id_, file_key, identity, record, deleted_file,
+            "delete_file", identity, id_, file_key, record, deleted_file,
             uow=uow)
 
         # We also commit the record in case the file was the `default_preview`
@@ -184,7 +184,7 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def delete_all_files(self, id_, identity, uow=None):
+    def delete_all_files(self, identity, id_, uow=None):
         """Delete all the files of the record."""
         record = self.get_record(id_, identity, "delete_files")
 
@@ -194,7 +194,7 @@ class FileService(Service):
         results = [record.files.delete(file_key) for file_key in file_keys]
 
         self.run_components(
-            "delete_all_files", id_, identity, record, results, uow=uow)
+            "delete_all_files", identity, id_, record, results, uow=uow)
 
         uow.register(RecordCommitOp(record))
 
@@ -209,13 +209,13 @@ class FileService(Service):
 
     @unit_of_work()
     def set_file_content(
-            self, id_, file_key, identity, stream, content_length=None,
+            self, identity, id_, file_key, stream, content_length=None,
             uow=None):
         """Save file content."""
         record = self.get_record(id_, identity, "create_files")
 
         self.run_components(
-            "set_file_content", id_, file_key, identity, stream,
+            "set_file_content", identity, id_, file_key, stream,
             content_length, record, uow=uow)
 
         return self.file_result_item(
@@ -226,12 +226,12 @@ class FileService(Service):
             links_tpl=self.file_links_item_tpl(id_),
         )
 
-    def get_file_content(self, id_, file_key, identity):
+    def get_file_content(self, identity, id_, file_key):
         """Retrieve file content."""
         record = self.get_record(id_, identity, "read_files")
 
         self.run_components(
-            "get_file_content", id_, file_key, identity, record)
+            "get_file_content", identity, id_, file_key, record)
 
         return self.file_result_item(
             self,

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -270,7 +270,7 @@ class RecordService(Service):
             errors=errors
         )
 
-    def read(self, id_, identity):
+    def read(self, identity, id_):
         """Retrieve a record."""
         # Resolve and require permission
         record = self.record_cls.pid.resolve(id_)
@@ -343,7 +343,7 @@ class RecordService(Service):
         return self.result_list(self, identity, results)
 
     @unit_of_work()
-    def update(self, id_, identity, data, revision_id=None, uow=None):
+    def update(self, identity, id_, data, revision_id=None, uow=None):
         """Replace a record."""
         record = self.record_cls.pid.resolve(id_)
 
@@ -375,7 +375,7 @@ class RecordService(Service):
         )
 
     @unit_of_work()
-    def delete(self, id_, identity, revision_id=None, uow=None):
+    def delete(self, identity, id_, revision_id=None, uow=None):
         """Delete a record from database and search indexes."""
         record = self.record_cls.pid.resolve(id_)
 

--- a/invenio_records_resources/tasks.py
+++ b/invenio_records_resources/tasks.py
@@ -18,4 +18,4 @@ from .proxies import current_service_registry
 def extract_file_metadata(service_id, record_id, file_key):
     """Process file."""
     service = current_service_registry.get(service_id)
-    service.extract_file_metadata(record_id, file_key, system_identity)
+    service.extract_file_metadata(system_identity, record_id, file_key)

--- a/tests/factories/test_service.py
+++ b/tests/factories/test_service.py
@@ -48,7 +48,7 @@ def test_simple_flow(app, identity_simple, db):
     id_ = item.id
 
     # Read it
-    read_item = service.read(id_, identity_simple)
+    read_item = service.read(identity_simple, id_)
     assert item.id == read_item.id
     assert item.data == read_item.data
 

--- a/tests/services/files/files_utils.py
+++ b/tests/services/files/files_utils.py
@@ -14,9 +14,9 @@ from io import BytesIO
 
 def add_file_to_record(file_service, recid, file_id, identity):
     """Add a file to the record."""
-    file_service.init_files(recid, identity, data=[{'key': file_id}])
+    file_service.init_files(identity, recid, data=[{'key': file_id}])
     file_service.set_file_content(
-        recid, file_id, identity, BytesIO(b'test file content')
+        identity, recid, file_id, BytesIO(b'test file content')
     )
-    result = file_service.commit_file(recid, file_id, identity)
+    result = file_service.commit_file(identity, recid, file_id)
     return result

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -39,54 +39,54 @@ def test_file_flow(
     }]
     # Initialize file saving
     result = file_service.init_files(
-        recid, identity_simple, file_to_initialise)
+        identity_simple, recid, file_to_initialise)
     assert result.to_dict()['entries'][0]['key'] == \
         file_to_initialise[0]['key']
 
     # for to_file in to_files:
     content = BytesIO(b'test file content')
     result = file_service.set_file_content(
-        recid, file_to_initialise[0]['key'], identity_simple, content,
+        identity_simple, recid, file_to_initialise[0]['key'], content,
         content.getbuffer().nbytes
     )
     # TODO figure response for succesfully saved file
     assert result.to_dict()['key'] == file_to_initialise[0]['key']
 
     result = file_service.commit_file(
-        recid, 'article.txt', identity_simple)
+        identity_simple, recid, 'article.txt')
     # TODO currently there is no status in the json between the initialisation
     # and the commiting.
     assert result.to_dict()['key'] == \
         file_to_initialise[0]['key']
 
     # List files
-    result = file_service.list_files(recid, identity_simple)
+    result = file_service.list_files(identity_simple, recid)
     assert result.to_dict()['entries'][0]['key'] == \
         file_to_initialise[0]['key']
 
     # Read file metadata
     result = file_service.read_file_metadata(
-        recid, 'article.txt', identity_simple)
+        identity_simple, recid, 'article.txt')
     assert result.to_dict()['key'] == \
         file_to_initialise[0]['key']
 
     # Retrieve file
     result = file_service.get_file_content(
-        recid, 'article.txt', identity_simple)
+        identity_simple, recid, 'article.txt')
     assert result.file_id == 'article.txt'
 
     # Delete file
     result = file_service.delete_file(
-        recid, 'article.txt', identity_simple)
+        identity_simple, recid, 'article.txt')
     assert result.file_id == 'article.txt'
 
     # Assert deleted
-    result = file_service.list_files(recid, identity_simple)
+    result = file_service.list_files(identity_simple, recid)
     assert result.entries
     assert len(list(result.entries)) == 0
 
     # Delete all remaining files
-    result = file_service.delete_all_files(recid, identity_simple)
+    result = file_service.delete_all_files(identity_simple, recid)
     assert list(result.entries) == []
 
 
@@ -99,7 +99,7 @@ def test_init_files(
     file_to_initialise = [{}]
 
     with pytest.raises(ValidationError) as e:
-        file_service.init_files(recid, identity_simple, file_to_initialise)
+        file_service.init_files(identity_simple, recid, file_to_initialise)
 
     error = e.value
     assert (
@@ -114,7 +114,7 @@ def test_init_files(
     }]
 
     result = file_service.init_files(
-        recid, identity_simple, file_to_initialise)
+        identity_simple, recid, file_to_initialise)
 
     entry = result.to_dict()['entries'][0]
     assert file_to_initialise[0]['key'] == entry['key']

--- a/tests/services/files/test_files_options.py
+++ b/tests/services/files/test_files_options.py
@@ -53,7 +53,7 @@ def test_disable_files_when_files_already_present_should_error(
     }
 
     with pytest.raises(ValidationError):
-        item = service.update(item.id, identity_simple, input_data)
+        item = service.update(identity_simple, item.id, input_data)
 
 
 def test_set_default_file_preview(
@@ -69,7 +69,7 @@ def test_set_default_file_preview(
         "default_preview": default_file
     }
 
-    item = service.update(item.id, identity_simple, input_data)
+    item = service.update(identity_simple, item.id, input_data)
 
     item_dict = item.to_dict()
     assert (
@@ -93,4 +93,4 @@ def test_set_default_file_preview_when_unknown_should_raise(
     }
 
     with pytest.raises(ValidationError):
-        item = service.update(item.id, identity_simple, input_data)
+        item = service.update(identity_simple, item.id, input_data)

--- a/tests/services/files/test_files_processing.py
+++ b/tests/services/files/test_files_processing.py
@@ -36,17 +36,17 @@ def test_image_meta_extraction(
 
     # Upload file
     file_service.init_files(
-        recid, identity_simple, [{'key': 'image.png'}])
+        identity_simple, recid, [{'key': 'image.png'}])
     file_service.set_file_content(
-        recid, 'image.png', identity_simple, image_fp)
+        identity_simple, recid, 'image.png', image_fp)
 
     # Commit (should send celery task)
     assert not task.delay.called
-    file_service.commit_file(recid, 'image.png', identity_simple)
+    file_service.commit_file(identity_simple, recid, 'image.png')
     assert task.delay.called
 
     # Call task manually
     extract_file_metadata(*task.delay.call_args[0])
 
-    item = file_service.read_file_metadata(recid, 'image.png', identity_simple)
+    item = file_service.read_file_metadata(identity_simple, recid, 'image.png')
     assert item.data['metadata'] == {"width": 1000, "height": 1000}

--- a/tests/services/test_service.py
+++ b/tests/services/test_service.py
@@ -30,7 +30,7 @@ def test_simple_flow(app, consumer, service, identity_simple, input_data):
     id_ = item.id
 
     # Read it
-    read_item = service.read(id_, identity_simple)
+    read_item = service.read(identity_simple, id_)
     assert item.id == read_item.id
     assert item.data == read_item.data
 
@@ -55,19 +55,19 @@ def test_simple_flow(app, consumer, service, identity_simple, input_data):
     # Update it
     data = read_item.data
     data['metadata']['title'] = 'New title'
-    update_item = service.update(id_, identity_simple, data)
+    update_item = service.update(identity_simple, id_, data)
     assert item.id == update_item.id
     assert update_item['metadata']['title'] == 'New title'
 
     # Delete it
-    assert service.delete(id_, identity_simple)
+    assert service.delete(identity_simple, id_)
 
     # Refresh to make changes live
     Record.index.refresh()
 
     # Retrieve it - deleted so cannot
     # - db
-    pytest.raises(PIDDeletedError, service.read, id_, identity_simple)
+    pytest.raises(PIDDeletedError, service.read, identity_simple, id_)
     # - search
     res = service.search(identity_simple, q=f"id:{id_}", size=25, page=1)
     assert res.total == 0

--- a/tests/services/test_service_revision_id.py
+++ b/tests/services/test_service_revision_id.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -36,13 +36,13 @@ def test_revision_id_update(app, service, identity_simple, input_data):
     data_revision_id = data['revision_id']
 
     # Update outdated record
-    pytest.raises(RevisionIdMismatchError, service.update, input_data.id,
-                  identity_simple, data, revision_id=100)
+    with pytest.raises(RevisionIdMismatchError):
+        service.update(identity_simple, input_data.id, data, revision_id=100)
 
     # Update with correct revision_id
 
     assert service.update(
-        input_data.id, identity_simple, data,
+        identity_simple, input_data.id, data,
         revision_id=data_revision_id
     )
 
@@ -54,10 +54,10 @@ def test_revision_id_delete(app, service, identity_simple, input_data):
     data_revision_id = data['revision_id']
 
     # Delete outdated record
-    pytest.raises(RevisionIdMismatchError, service.delete, input_data.id,
-                  identity_simple, revision_id=100)
+    with pytest.raises(RevisionIdMismatchError):
+        service.delete(identity_simple, input_data.id, revision_id=100)
 
     # Delete with correct revision_id
 
     assert service.delete(
-        input_data.id, identity_simple, revision_id=data_revision_id)
+        identity_simple, input_data.id, revision_id=data_revision_id)


### PR DESCRIPTION
- closes #258 
- Because this PR changes some function declarations, other (see below) PRs in other repos will need to be merged as well. Then a version bump should be required, but since at time of writing 0.18 has been made and is not part of the LTS or STS, we can piggy back on it I think (0.18.2 for instance). 

Downstream PRs:
- https://github.com/inveniosoftware/invenio-drafts-resources/pull/175
- https://github.com/inveniosoftware/invenio-vocabularies/pull/121
- https://github.com/inveniosoftware/invenio-requests/pull/101
- https://github.com/inveniosoftware/invenio-communities/pull/375
- https://github.com/inveniosoftware/invenio-rdm-records/pull/863
- https://github.com/inveniosoftware/invenio-app-rdm/pull/1154