### PR TITLE
Lift up entity reference stuff from Invenio-Requests

### DIFF
--- a/invenio_records_resources/records/jsonschemas/definitions-v1.0.0.json
+++ b/invenio_records_resources/records/jsonschemas/definitions-v1.0.0.json
@@ -2,6 +2,16 @@
   "$schema": {
     "type": "string"
   },
+  "entity_reference": {
+    "description": "Reference to an entity, with the type as key and ID as value",
+    "type": ["object", "null"],
+    "additionalProperties": false,
+    "patternProperties": {
+      "^[a-z_]+$": {
+        "type": "string"
+      }
+    }
+  },
   "identifier": {
     "description": "An identifier.",
     "type": "string"

--- a/invenio_records_resources/records/systemfields/calculated.py
+++ b/invenio_records_resources/records/systemfields/calculated.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Systemfield for calculated properties of records."""
+
+
+import abc
+
+from invenio_records.systemfields import SystemField
+
+
+class CalculatedField(SystemField, abc.ABC):
+    """Systemfield for returning calculated properties."""
+
+    def __init__(self, key=None, use_cache=False):
+        """Constructor."""
+        super().__init__(key)
+        self._use_cache = use_cache
+
+    def obj(self, instance):
+        """Calculate and return the record's property."""
+        # per default, no caching should be used
+        if not self._use_cache:
+            return self.calculate(instance)
+
+        # check the cache
+        obj = self._get_cache(instance)
+        if obj is not None:
+            return obj
+
+        # calculate and set cache
+        obj = self.calculate(instance)
+        self._set_cache(instance, obj)
+        return obj
+
+    def __get__(self, record, owner=None):
+        """Calculate and return the record's property."""
+        if record is None:
+            # access by class
+            return self
+
+        return self.obj(record)
+
+    def __set__(self, record, value):
+        """Prevent setting of a calculated property."""
+        msg = f"Cannot set value for calculated field '{self.key}'"
+        raise AttributeError(msg)
+
+    @abc.abstractmethod
+    def calculate(self, record):
+        """Logic for calculating the record's property."""
+        return None

--- a/invenio_records_resources/records/systemfields/entity_reference.py
+++ b/invenio_records_resources/records/systemfields/entity_reference.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Systemfield for managing referenced entities in request."""
+
+from functools import partial
+
+from invenio_records.systemfields import SystemField
+
+from ...references.resolvers import EntityProxy
+
+
+class ReferencedEntityField(SystemField):
+    """Systemfield for managing the request type."""
+
+    def __init__(
+        self, key=None, reference_check_func=None, resolver_registry=None
+    ):
+        """Constructor."""
+        super().__init__(key=key)
+        self._ref_check = reference_check_func
+        self._registry = resolver_registry
+
+    def _check_reference(self, instance, ref_dict):
+        """Check if the reference is accepted."""
+        if self._ref_check is None:
+            return True
+
+        return self._ref_check(instance, ref_dict)
+
+    def set_obj(self, instance, obj):
+        """Set the referenced entity."""
+        # allow the setter to be used with a reference dict,
+        # an entity proxy, or an actual entity
+        if not isinstance(obj, dict):
+            if isinstance(obj, EntityProxy):
+                obj = obj.reference_dict
+            elif obj is not None:
+                obj = self._registry.reference_entity(obj, raise_=True)
+
+        # check if the reference is allowed
+        if not self._check_reference(instance, obj):
+            raise ValueError(f"Invalid reference for '{self.key}': {obj}")
+
+        # set dictionary key and reset the cache
+        self.set_dictkey(instance, obj)
+        self._set_cache(instance, None)
+
+    def __set__(self, record, value):
+        """Set the referenced entity."""
+        assert record is not None
+        self.set_obj(record, value)
+
+    def obj(self, instance):
+        """Get the referenced entity as an ``EntityProxy``."""
+        obj = self._get_cache(instance)
+        if obj is not None:
+            return obj
+
+        reference_dict = self.get_dictkey(instance)
+        if reference_dict is None:
+            # TODO maybe use a `NullProxy` instead?
+            return None
+
+        obj = self._registry.resolve_entity_proxy(reference_dict)
+        self._set_cache(instance, obj)
+        return obj
+
+    def __get__(self, record, owner=None):
+        """Get the referenced entity as an ``EntityProxy``."""
+        if record is None:
+            # access by class
+            return self
+
+        return self.obj(record)
+
+
+def check_allowed_references(
+    get_allows_none, get_allowed_types, request, ref_dict
+):
+    """Check the reference according to rules specific to requests.
+
+    In case the ``ref_dict`` is ``None``, it will check if this is allowed
+    for the reference at hand.
+    Otherwise, it will check if the reference dict's key (i.e. the TYPE)
+    is allowed.
+    """
+    if ref_dict is None:
+        return get_allows_none(request)
+
+    if not len(ref_dict) == 1:
+        # we expect a ref_dict to have the shape {"TYPE": "ID"}
+        return False
+
+    ref_type = list(ref_dict.keys())[0]
+    return ref_type in get_allowed_types(request)
+
+
+check_allowed_creators = partial(
+    check_allowed_references,
+    lambda r: r.type.creator_can_be_none,
+    lambda r: r.type.allowed_creator_ref_types,
+)
+"""Check function specific for the ``created_by`` field of requests."""
+
+check_allowed_receivers = partial(
+    check_allowed_references,
+    lambda r: r.type.receiver_can_be_none,
+    lambda r: r.type.allowed_receiver_ref_types,
+)
+"""Check function specific for the ``receiver`` field of requests."""
+
+check_allowed_topics = partial(
+    check_allowed_references,
+    lambda r: r.type.topic_can_be_none,
+    lambda r: r.type.allowed_topic_ref_types,
+)
+"""Check function specific for the ``topic`` field of requests."""

--- a/invenio_records_resources/references/__init__.py
+++ b/invenio_records_resources/references/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Module for entity resolvers."""
+
+from .registry import ResolverRegistryBase
+from .resolvers import EntityResolver, RecordResolver, UserResolver
+
+__all__ = (
+    "EntityResolver",
+    "RecordResolver",
+    "ResolverRegistryBase",
+    "UserResolver",
+)

--- a/invenio_records_resources/references/registry.py
+++ b/invenio_records_resources/references/registry.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Registry for easy access to the registered entity resolvers."""
+
+from abc import ABC, abstractmethod
+
+from invenio_access.permissions import system_process
+
+
+class ResolverRegistryBase(ABC):
+    """Base class for a resolver registry."""
+
+    @classmethod
+    @abstractmethod
+    def get_registered_resolvers(cls):
+        """Get all currently registered resolvers."""
+        raise NotImplementedError()
+
+    @classmethod
+    def resolve_entity_proxy(cls, reference_dict, raise_=False):
+        """Get a proxy for the referenced entity via the configured resolvers.
+
+        If ``REQUESTS_ENTITY_RESOLVERS`` does not contain a matching
+        EntityResolver for the given ``reference_dict``, the ``raise_``
+        parameter determines whether a ``ValueError`` is raised or
+        ``None`` is returned.
+        """
+        for resolver in cls.get_registered_resolvers():
+            if resolver.matches_reference_dict(reference_dict):
+                return resolver.get_entity_proxy(reference_dict, check=False)
+
+        if raise_:
+            msg = f"No matching resolver registered for: {reference_dict}"
+            raise ValueError(msg)
+
+        return None
+
+    @classmethod
+    def resolve_entity(cls, reference_dict, raise_=False):
+        """Resolve the referenced entity via the configured resolvers.
+
+        This calls ``resolve_entity_proxy()`` and then ``resolve()`` on
+        the proxy.
+        Note that this may create an expensive lookup, like a DB query.
+        """
+        proxy = cls.resolve_entity_proxy(reference_dict, raise_=raise_)
+
+        if proxy is None:
+            return None
+
+        return proxy.resolve()
+
+    @classmethod
+    def resolve_need(cls, reference_dict, raise_=False):
+        """Get the need for the referenced entity via the configured resolvers.
+
+        This calls ``resolve_entity_proxy()`` and then ``get_need()`` on
+        the proxy.
+        Note: If the concept of needs is not applicable to the referenced
+        type of entity (e.g. ``Request``), ``None`` is returned.
+        """
+        proxy = cls.resolve_entity_proxy(reference_dict, raise_=raise_)
+
+        if proxy is None:
+            return None
+
+        return proxy.get_need()
+
+    @classmethod
+    def reference_entity(cls, entity, raise_=False):
+        """Create a reference dict for the entity via the configured resolvers.
+
+        If ``REQUESTS_ENTITY_RESOLVERS`` does not contain a matching
+        EntityResolver for the given ``entity``, the ``raise_`` parameter
+        determines whether a ``ValueError`` is raised or ``None`` is returned.
+        """
+        for resolver in cls.get_registered_resolvers():
+            if resolver.matches_entity(entity):
+                return resolver.reference_entity(entity, check=False)
+
+        if raise_:
+            msg = f"No matching resolver registered for: {type(entity)}"
+            raise ValueError(msg)
+
+        return None
+
+    @classmethod
+    def reference_identity(cls, identity, raise_=False):
+        """Create a reference dict for the user behind the given identity."""
+        if system_process in identity.provides:
+            return None
+
+        return {"user": str(identity.id)}

--- a/invenio_records_resources/references/resolvers/__init__.py
+++ b/invenio_records_resources/references/resolvers/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Requests is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Default entity resolvers and proxies."""
+
+from .base import EntityProxy, EntityResolver
+from .records import RecordResolver
+from .users import UserResolver
+
+__all__ = (
+    "EntityProxy",
+    "EntityResolver",
+    "RecordResolver",
+    "UserResolver",
+)

--- a/invenio_records_resources/references/resolvers/base.py
+++ b/invenio_records_resources/references/resolvers/base.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Base class for entity resolvers."""
+
+from abc import ABC, abstractmethod
+
+
+def _parse_ref_dict(reference_dict, strict=True):
+    """Parse the referenced dict into a tuple (TYPE, ID).
+
+    The ``strict`` parameter controls if the number of keys in the
+    reference dict is checked strictly or not.
+    """
+    keys = list(reference_dict.keys())
+
+    if strict and len(keys) != 1:
+        raise ValueError(
+            "Reference dicts may only have one property! "
+            f"Offending dict: {reference_dict}"
+        )
+
+    if not keys:
+        return None
+
+    type_ = keys[0]
+    id_ = reference_dict[type_]
+    return (type_, id_)
+
+
+class EntityProxy(ABC):
+    """Proxy for a type of entity which only resolves the entity if requested.
+
+    EntityProxies are responsible for resolving the entities referenced in
+    the reference dicts, and thus act as another layer of abstraction.
+    They provide a unified interface for resolving the actual entities from
+    the dicts, or creating Needs from the references (which is useful for
+    permission checks, for instance on owners of records or requests).
+    Also, they enable the actual entity to be lazily loaded via the explicit
+    ``resolve()`` operation, which prevents unnecessary lookups if the entity
+    is not of importance (e.g. when only the Need is relevant).
+    After the first lookup, the resolved entity will be cached by the proxy
+    object.
+    """
+
+    def __init__(self, reference_dict):
+        """Constructor."""
+        self._ref_dict = reference_dict
+        self._entity = None
+
+    def __repr__(self):
+        """Return repr(self)."""
+        return f"<{type(self).__name__} {self._ref_dict} ({self._entity})>"
+
+    def _parse_ref_dict(self, ref_dict):
+        """Parse the referenced dict into a tuple (TYPE, ID)."""
+        return _parse_ref_dict(ref_dict)
+
+    def _parse_ref_dict_type(self, ref_dict):
+        """Parse the TYPE from the reference dict."""
+        return self._parse_ref_dict(ref_dict)[0]
+
+    def _parse_ref_dict_id(self, ref_dict):
+        """Parse the ID from the reference dict."""
+        return self._parse_ref_dict(ref_dict)[1]
+
+    @property
+    def reference_dict(self):
+        """Get the proxy's reference dict."""
+        return self._ref_dict
+
+    def resolve(self):
+        """Resolve the referenced entity via a query."""
+        if self._entity is not None:
+            # caching
+            return self._entity
+
+        self._entity = self._resolve()
+        return self._entity
+
+    @abstractmethod
+    def _resolve(self):
+        """The logic for performing the actual resolve operation.
+
+        This method must be implemented by concrete subclasses.
+        Note: The caching logic is already handled in ``resolve()``,
+        so this method should contain the pure resolution logic.
+        """
+        return None
+
+    @abstractmethod
+    def get_need(self):
+        """Get the Need for the referenced entity, if applicable.
+
+        If the concept is not applicable for this resolver's type of entities,
+        ``None`` will be returned.
+        """
+        return None
+
+
+class EntityResolver(ABC):
+    """Translation layer between reference dicts and entities (or proxies).
+
+    The resolvers are a layer of abstraction between the reference dicts and
+    their referenced entities.
+    They are directly responsible for handling the reference dumping direction
+    themselves (i.e. creating reference dicts from entities), while the other
+    direction (i.e. resolving entities from reference dicts) is the
+    responsibility of the EntityProxies created by the resolvers.
+    """
+
+    def _parse_ref_dict(self, ref_dict):
+        """Parse the referenced dict into a tuple (TYPE, ID)."""
+        return _parse_ref_dict(ref_dict)
+
+    def _parse_ref_dict_type(self, ref_dict):
+        """Parse the TYPE from the reference dict."""
+        return self._parse_ref_dict(ref_dict)[0]
+
+    def _parse_ref_dict_id(self, ref_dict):
+        """Parse the ID from the reference dict."""
+        return self._parse_ref_dict(ref_dict)[1]
+
+    def get_entity_proxy(self, ref_dict, check=True):
+        """Check compatibility and get a proxy for the referenced entity.
+
+        This method will optionally check the shape of the given reference
+        dict via ``matches_reference_dict()`` before creating a proxy via
+        ``_get_entity_proxy()``.
+        If this check fails, a ``ValueError`` will be raised.
+        """
+        if check and not self.matches_reference_dict(ref_dict):
+            raise ValueError(
+                f"{type(self).__name__} cannot handle "
+                f"the following reference dict: {ref_dict}"
+            )
+
+        return self._get_entity_proxy(ref_dict)
+
+    def reference_entity(self, entity, check=True):
+        """Check compatibility and create a reference dict for the entity.
+
+        This method will perform an optional instance check of the given
+        entity via ``matches_entity()`` before dumping a reference via
+        ``_reference_entity()``.
+        If this check fails, a ``ValueError`` will be raised.
+        """
+        if check and not self.matches_entity(entity):
+            raise ValueError(
+                f"{type(self).__name__} cannot handle "
+                f"the following entity: {entity}"
+            )
+
+        return self._reference_entity(entity)
+
+    @abstractmethod
+    def matches_reference_dict(self, ref_dict):
+        """Check if the ref_dict matches the expectations of this resolver."""
+        return False
+
+    @abstractmethod
+    def matches_entity(self, entity):
+        """Check if the entity matches the expectations of this resolver."""
+        return False
+
+    @abstractmethod
+    def _get_entity_proxy(self, ref_dict):
+        """The logic for building a proxy for the referenced entity.
+
+        Since the compatibility checks are already taken care of, this
+        method can assume that the data is valid and can focus on simply
+        creating the proxy for the referenced entity.
+        """
+        return None
+
+    @abstractmethod
+    def _reference_entity(self, entity):
+        """The logic building a reference dict from the given entity.
+
+        Since the compatibility checks are already taken care of, this method
+        can assume that the entity is compatible and can focus on simply
+        creating the reference dict for the given entity.
+        """
+        return None

--- a/invenio_records_resources/references/resolvers/records.py
+++ b/invenio_records_resources/references/resolvers/records.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+# Copyright (C) 2021 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Resolver for records."""
+
+from sqlalchemy.exc import StatementError
+from sqlalchemy.orm.exc import NoResultFound
+
+from .base import EntityProxy, EntityResolver
+
+
+class RecordProxy(EntityProxy):
+    """Resolver proxy for a Record entity using the pid."""
+
+    def __init__(self, ref_dict, record_cls):
+        """Constructor.
+
+        :param record_cls: The record class to use.
+        """
+        super().__init__(ref_dict)
+        self.record_cls = record_cls
+
+    def _resolve(self):
+        """Resolve the Record from the proxy's reference dict."""
+        pid_value = self._parse_ref_dict_id(self._ref_dict)
+        return self.record_cls.pid.resolve(pid_value)
+
+    def get_need(self):
+        """Return None since Needs are not applicable to records."""
+        return None
+
+
+class RecordPKProxy(RecordProxy):
+    """Resolver proxy for a Record entity using the UUID."""
+
+    def _resolve(self):
+        """Resolve the Record from the proxy's reference dict."""
+        id_ = self._parse_ref_dict_id(self._ref_dict)
+        try:
+            return self.record_cls.get_record(id_)
+        except StatementError as exc:
+            raise NoResultFound() from exc
+
+
+class RecordResolver(EntityResolver):
+    """Resolver for records."""
+
+    def __init__(self, record_cls, type_key="record", proxy_cls=RecordProxy):
+        """Constructor.
+
+        :param record_cls: The record class to use.
+        :param type_key: The value to use for the TYPE part of the ref_dicts.
+        """
+        self.record_cls = record_cls
+        self.type_key = type_key
+        self.proxy_cls = proxy_cls
+
+    def matches_entity(self, entity):
+        """Check if the entity is a record."""
+        return isinstance(entity, self.record_cls)
+
+    def _reference_entity(self, entity):
+        """Create a reference dict for the given record."""
+        return {self.type_key: str(entity.pid.pid_value)}
+
+    def matches_reference_dict(self, ref_dict):
+        """Check if the reference dict references a request."""
+        return self._parse_ref_dict_type(ref_dict) == self.type_key
+
+    def _get_entity_proxy(self, ref_dict):
+        """Return a RecordProxy for the given reference dict."""
+        return self.proxy_cls(ref_dict, self.record_cls)

--- a/invenio_records_resources/references/resolvers/users.py
+++ b/invenio_records_resources/references/resolvers/users.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Resolver and proxy for users."""
+
+
+from flask_principal import UserNeed
+from invenio_accounts.models import User
+
+from .base import EntityProxy, EntityResolver
+
+
+class UserProxy(EntityProxy):
+    """Resolver proxy for a User entity."""
+
+    def _resolve(self):
+        """Resolve the User from the proxy's reference dict."""
+        user_id = int(self._parse_ref_dict_id(self._ref_dict))
+        return User.query.get(user_id)
+
+    def get_need(self):
+        """Get the UserNeed for the referenced user."""
+        user_id = int(self._parse_ref_dict_id(self._ref_dict))
+        return UserNeed(user_id)
+
+
+class UserResolver(EntityResolver):
+    """Resolver for users."""
+
+    type_id = 'user'
+
+    def matches_reference_dict(self, ref_dict):
+        """Check if the reference dict references a user."""
+        return self._parse_ref_dict_type(ref_dict) == "user"
+
+    def _reference_entity(self, entity):
+        """Create a reference dict for the given user."""
+        return {"user": str(entity.id)}
+
+    def matches_entity(self, entity):
+        """Check if the entity is a user."""
+        return isinstance(entity, User)
+
+    def _get_entity_proxy(self, ref_dict):
+        """Return a UserProxy for the given reference dict."""
+        return UserProxy(ref_dict)

--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2022 TU Wien.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more

--- a/invenio_records_resources/services/references/__init__.py
+++ b/invenio_records_resources/services/references/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Service-related things for entity references."""
+
+from .schema import EntityReferenceBaseSchema
+
+__all__ = ("EntityReferenceBaseSchema",)

--- a/invenio_records_resources/services/references/schema.py
+++ b/invenio_records_resources/services/references/schema.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Schema for entity references."""
+
+from marshmallow import RAISE, Schema, ValidationError, fields, \
+    validates_schema
+
+
+#
+# Schema for entity references
+#
+class EntityReferenceBaseSchema(Schema):
+    """Base schema for entity references, allowing only a single key.
+
+    Example of an allowed value: ``{"user": 1}``.
+    Example of a disallowed value: ``{"user": 1, "record": "abcd-1234"}``.
+    """
+
+    @validates_schema
+    def there_can_be_only_one(self, data, **kwargs):
+        """Only allow a single key."""
+        if len(data) != 1:
+            raise ValidationError("Entity references may only have one key")
+
+    @classmethod
+    def create_from_dict(cls, allowed_types, special_fields=None):
+        """Create an entity reference schema based on the allowed ref types.
+
+        Per default, a ``fields.String()`` field is registered for each of
+        the type names in the ``allowed_types`` list.
+        The field type can be customized by providing an entry in the
+        ``special_fields`` dict, with the type name as key and the field type
+        as value (e.g. ``{"user": fields.Integer()}``).
+        """
+        field_types = special_fields or {}
+        for ref_type in allowed_types:
+            # each type would be a String field per default
+            field_types.setdefault(ref_type, fields.String())
+
+        return cls.from_dict(
+            {ref_type: field_types[ref_type] for ref_type in allowed_types}
+        )


### PR DESCRIPTION
Partially closes https://github.com/inveniosoftware/invenio-requests/issues/12

In a follow-up task, we should probably adjust the owners structure in the parent records' access field (https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/records/systemfields/access/owners.py) to use the newly created mechanisms