### PR TITLE
Remove accidentally lifted-up helper functions from Invenio-Requests

### DIFF
--- a/invenio_records_resources/records/systemfields/entity_reference.py
+++ b/invenio_records_resources/records/systemfields/entity_reference.py
@@ -99,25 +99,3 @@ def check_allowed_references(
 
     ref_type = list(ref_dict.keys())[0]
     return ref_type in get_allowed_types(request)
-
-
-check_allowed_creators = partial(
-    check_allowed_references,
-    lambda r: r.type.creator_can_be_none,
-    lambda r: r.type.allowed_creator_ref_types,
-)
-"""Check function specific for the ``created_by`` field of requests."""
-
-check_allowed_receivers = partial(
-    check_allowed_references,
-    lambda r: r.type.receiver_can_be_none,
-    lambda r: r.type.allowed_receiver_ref_types,
-)
-"""Check function specific for the ``receiver`` field of requests."""
-
-check_allowed_topics = partial(
-    check_allowed_references,
-    lambda r: r.type.topic_can_be_none,
-    lambda r: r.type.allowed_topic_ref_types,
-)
-"""Check function specific for the ``topic`` field of requests."""

--- a/invenio_records_resources/version.py
+++ b/invenio_records_resources/version.py
@@ -13,4 +13,4 @@ This file is imported by ``invenio_records_resources.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.18.2"
+__version__ = "0.18.3"


### PR DESCRIPTION
Some helper functions were accidentally lifted that aren't useful outside of Invenio-Requests.
Also, this bumps the version to v0.18.3