### PR TITLE
fix: intersect different filter categories instead of union

### DIFF
--- a/invenio_records_resources/services/records/params/facets.py
+++ b/invenio_records_resources/services/records/params/facets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2021 CERN.
+# Copyright (C)      2022 Graz University of Technology.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -48,7 +49,7 @@ class FacetsParam(ParamInterpreter):
 
         post_filter = filters[0]
         for f in filters[1:]:
-            post_filter |= f
+            post_filter &= f
 
         return search.post_filter(post_filter)
 

--- a/tests/mock_module/config.py
+++ b/tests/mock_module/config.py
@@ -15,7 +15,8 @@ from invenio_records_resources.services.files.links import FileLink
 from invenio_records_resources.services.records.components import \
     FilesOptionsComponent
 from invenio_records_resources.services.records.config import SearchOptions
-from invenio_records_resources.services.records.facets import NestedTermsFacet
+from invenio_records_resources.services.records.facets import \
+    NestedTermsFacet, TermsFacet
 from invenio_records_resources.services.records.links import RecordLink, \
     pagination_links
 from invenio_records_resources.services.records.params.querystr import \
@@ -35,6 +36,10 @@ class MockSearchOptions(SearchOptions):
             subfield='metadata.type.subtype',
             splitchar="**",
             label='Type'
+        ),
+        'subject': TermsFacet(
+            field='metadata.subject',
+            label='Subject',
         )
     }
 

--- a/tests/mock_module/mappings/v6/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/v6/records/record-v1.0.0.json
@@ -21,6 +21,9 @@
                   "type": "keyword"
                 }
               }
+            },
+            "subject": {
+              "type": "keyword"
             }
           }
         },

--- a/tests/mock_module/mappings/v7/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/v7/records/record-v1.0.0.json
@@ -20,6 +20,9 @@
                 "type": "keyword"
               }
             }
+          },
+          "subject": {
+            "type": "keyword"
           }
         }
       },

--- a/tests/mock_module/schemas.py
+++ b/tests/mock_module/schemas.py
@@ -29,6 +29,7 @@ class MetadataSchema(Schema):
 
     title = fields.Str(required=True, validate=validate.Length(min=3))
     type = fields.Nested(TypeSchema)
+    subject = fields.Str()
 
 
 class RecordSchema(BaseRecordSchema):

--- a/tests/resources/test_resource_faceting.py
+++ b/tests/resources/test_resource_faceting.py
@@ -53,6 +53,10 @@ def test_aggregating(client, headers, three_indexed_records):
     response_aggs = response.json["aggregations"]
 
     expected_aggs = {
+        "subject": {
+            "buckets": [],
+            "label": "Subject",
+        },
         "type": {
             "label": "Type",
             "buckets": [
@@ -101,6 +105,10 @@ def test_post_filtering(client, headers, three_indexed_records):
     # Test aggregation is the same
     response_aggs = response.json["aggregations"]
     expected_aggs = {
+        "subject": {
+            "buckets": [],
+            "label": "Subject",
+        },
         "type": {
             "label": "Type",
             "buckets": [

--- a/tests/services/test_service_facets.py
+++ b/tests/services/test_service_facets.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -22,12 +23,13 @@ def records(app, service, identity_simple):
     items = []
     for idx in range(2):
         data = {
-           'metadata': {
+            'metadata': {
                 'title': f'00{idx}',
                 'type': {
                     'type': f'Foo{idx}',
                     'subtype': f'Bar{idx}'
-                }
+                },
+                'subject': f'Subject{idx}',
             },
         }
         items.append(service.create(identity_simple, data))
@@ -45,14 +47,100 @@ def test_facets(app, service, identity_simple, records):
     service_aggs = res.aggregations
 
     expected_aggs = {
+        "subject": {
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "is_selected": False,
+                    "key": "Subject0",
+                    "label": "Subject0",
+                },
+                {
+                    "doc_count": 1,
+                    "is_selected": False,
+                    "key": "Subject1",
+                    "label": "Subject1",
+                },
+            ],
+            "label": "Subject",
+        },
+        "type": {
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "Bar0",
+                                "label": "Bar0",
+                            }
+                        ]
+                    },
+                    "is_selected": False,
+                    "key": "Foo0",
+                    "label": "Foo0",
+                },
+                {
+                    "doc_count": 1,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "Bar1",
+                                "label": "Bar1",
+                            }
+                        ]
+                    },
+                    "is_selected": False,
+                    "key": "Foo1",
+                    "label": "Foo1",
+                },
+            ],
+            "label": "Type",
+        },
+    }
+
+    assert expected_aggs == service_aggs
+
+
+def test_facets_post_filtering_union(
+    app, service, identity_simple, records
+):
+    """Same facets should result in union of results."""
+    # Search it
+    res = service.search(
+        identity_simple, facets={'type': ['Foo0', 'Foo1']}
+    )
+    service_aggs = res.aggregations
+    expected_aggs = {
+        "subject": {
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "is_selected": False,
+                    "key": "Subject0",
+                    "label": "Subject0",
+                },
+                {
+                    "doc_count": 1,
+                    "is_selected": False,
+                    "key": "Subject1",
+                    "label": "Subject1",
+                },
+            ],
+            "label": "Subject",
+        },
         "type": {
             "label": "Type",
             "buckets": [
                 {
                     "doc_count": 1,
                     "key": "Foo0",
-                    "is_selected": False,
                     "label": "Foo0",
+                    "is_selected": True,
                     "inner": {
                         "buckets": [
                             {
@@ -62,13 +150,13 @@ def test_facets(app, service, identity_simple, records):
                                 "is_selected": False,
                             },
                         ],
-                    }
+                    },
                 },
                 {
                     "doc_count": 1,
                     "key": "Foo1",
-                    "is_selected": False,
                     "label": "Foo1",
+                    "is_selected": True,
                     "inner": {
                         "buckets": [
                             {
@@ -78,12 +166,85 @@ def test_facets(app, service, identity_simple, records):
                                 "is_selected": False,
                             },
                         ],
-                    }
+                    },
                 },
             ],
         }
     }
     assert expected_aggs == service_aggs
+    # Test hits contain items from both
+    assert 2 == len(res)
+    assert set(["000", "001"]) == set([h["metadata"]["title"] for h in res])
+
+
+def test_facets_post_filtering_intersection(
+    app, service, identity_simple, records
+):
+    """Different facets should result in intersection of results."""
+    # No records match both facets
+    res = service.search(
+        identity_simple, facets={"type": ["Foo1"], "subject": ["Subject0"]}
+    )
+    service_aggs = res.aggregations
+    expected_aggs = {
+        'subject': {
+            'buckets': [
+                {
+                    'doc_count': 1,
+                    'is_selected': True,
+                    'key': 'Subject0',
+                    'label': 'Subject0',
+                },
+                {
+                    'doc_count': 1,
+                    'is_selected': False,
+                    'key': 'Subject1',
+                    'label': 'Subject1',
+                },
+            ],
+            'label': 'Subject',
+        },
+        "type": {
+            "label": "Type",
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "key": "Foo0",
+                    "label": "Foo0",
+                    "is_selected": False,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "key": "Bar0",
+                                "label": "Bar0",
+                                "is_selected": False,
+                            },
+                        ],
+                    },
+                },
+                {
+                    "doc_count": 1,
+                    "key": "Foo1",
+                    "label": "Foo1",
+                    "is_selected": True,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "key": "Bar1",
+                                "label": "Bar1",
+                                "is_selected": False,
+                            },
+                        ],
+                    },
+                },
+            ],
+        }
+    }
+    assert expected_aggs == service_aggs
+    # Test hits are filtered
+    assert 0 == len(res)
 
 
 def test_facets_post_filtering(app, service, identity_simple, records):
@@ -92,6 +253,23 @@ def test_facets_post_filtering(app, service, identity_simple, records):
     res = service.search(identity_simple, facets={'type': ['Foo1']})
     service_aggs = res.aggregations
     expected_aggs = {
+        "subject": {
+            "buckets": [
+                {
+                    "doc_count": 1,
+                    "is_selected": False,
+                    "key": "Subject0",
+                    "label": "Subject0",
+                },
+                {
+                    "doc_count": 1,
+                    "is_selected": False,
+                    "key": "Subject1",
+                    "label": "Subject1",
+                },
+            ],
+            "label": "Subject",
+        },
         "type": {
             "label": "Type",
             "buckets": [


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1263
![Screenshot from 2022-02-23 13-07-28](https://user-images.githubusercontent.com/72449192/155347757-9a67be0d-c982-4c02-be0e-e0ee4041f92a.png)

