### PR TITLE
service: set indexer routing key at producer level

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -34,13 +34,20 @@ class RecordService(Service):
     def indexer(self):
         """Factory for creating an indexer instance."""
         return self.config.indexer_cls(
+            # the routing key is mandatory in the indexer constructor since
+            # it is afterwards passed explicitly to the created consumers
+            # and producers. this means that it is not strictly necessary to
+            # pass it to the queue constructor. however, it is passed for
+            # consistency (in case the queue is used by itself) and to help
+            # entity declaration on publish.
             queue=LocalProxy(
                 lambda: Queue(
                     self.config.indexer_queue_name,
                     exchange=current_app.config["INDEXER_MQ_EXCHANGE"],
-                    routing_key=current_app.config["INDEXER_MQ_ROUTING_KEY"],
+                    routing_key=self.config.indexer_queue_name,
                 )
             ),
+            routing_key=self.config.indexer_queue_name,
             record_cls=self.config.record_cls,
             record_to_index=self.record_to_index,
             record_dumper=self.config.index_dumper,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,7 @@ fixtures are available.
 """
 
 import pytest
-from celery.messaging import establish_connection
 from invenio_app.factory import create_api as _create_api
-from kombu.compat import Consumer
 from mock_module.config import MockFileServiceConfig
 
 from invenio_records_resources.services import FileService
@@ -44,33 +42,6 @@ def extra_entry_points():
 def create_app(instance_path, entry_points):
     """Application factory fixture."""
     return _create_api
-
-
-@pytest.fixture(scope='function')
-def queue(app):
-    """Declare an clean the indexer queue."""
-    # TODO: Move this fixture to pytest-invenio
-    queue = app.config['INDEXER_MQ_QUEUE']
-
-    with establish_connection() as c:
-        q = queue(c)
-        q.declare()
-        q.purge()
-
-    return queue
-
-
-@pytest.fixture(scope='function')
-def consumer(app, queue):
-    """Get a consumer on the queue object for testing bulk operations."""
-    # TODO: Move this fixture to pytest-invenio
-    with establish_connection() as c:
-        yield Consumer(
-            connection=c,
-            queue=app.config['INDEXER_MQ_QUEUE'].name,
-            exchange=app.config['INDEXER_MQ_EXCHANGE'].name,
-            routing_key=app.config['INDEXER_MQ_ROUTING_KEY'],
-        )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
The routing key was defined at queue level, however the publish method was using that of the producer. This lead to messages being sent to two queues. For example on community members update it was sending to `members` (queue level routing key) and `records` (producer level routing key - default)