### PR TITLE
record files: add error response for unknown files

### DIFF
--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -10,7 +10,7 @@
 """Invenio Record File Resources."""
 
 import marshmallow as ma
-from flask import g
+from flask import abort, g
 from flask_resources import (
     JSONDeserializer,
     RequestBodyParser,
@@ -115,6 +115,10 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
         )
+
+        if item is None:
+            abort(404)
+
         return item.to_dict(), 200
 
     @request_view_args
@@ -128,6 +132,10 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.view_args["key"],
             resource_requestctx.data or {},
         )
+
+        if item is None:
+            abort(404)
+
         return item.to_dict(), 200
 
     @request_view_args
@@ -160,6 +168,10 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
         )
+
+        if item is None:
+            abort(404)
+
         return item.send_file(), 200
 
     @request_view_args
@@ -175,4 +187,8 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.data["request_stream"],
             content_length=resource_requestctx.data["request_content_length"],
         )
+
+        if item is None:
+            abort(404)
+
         return item.to_dict(), 200

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -95,6 +95,9 @@ class FileService(Service):
         """Update the metadata of a file."""
         record = self.get_record(id_, identity, "create_files")
 
+        if file_key not in record.files:
+            return None
+
         self.run_components(
             "update_file_metadata", identity, id_, file_key, record, data, uow=uow
         )
@@ -111,6 +114,9 @@ class FileService(Service):
         """Read the metadata of a file."""
         record = self.get_record(id_, identity, "read_files")
 
+        if file_key not in record.files:
+            return None
+
         self.run_components("read_file_metadata", identity, id_, file_key, record)
 
         return self.file_result_item(
@@ -125,6 +131,10 @@ class FileService(Service):
     def extract_file_metadata(self, identity, id_, file_key, uow=None):
         """Extract metadata from a file and update the file metadata file."""
         record = self.get_record(id_, identity, "create_files")
+
+        if file_key not in record.files:
+            return None
+
         file_record = record.files[file_key]
 
         self.run_components(
@@ -151,6 +161,9 @@ class FileService(Service):
     def commit_file(self, identity, id_, file_key, uow=None):
         """Commit a file upload."""
         record = self.get_record(id_, identity, "create_files")
+
+        if file_key not in record.files:
+            return None
 
         self.run_components("commit_file", identity, id_, file_key, record, uow=uow)
 
@@ -213,6 +226,9 @@ class FileService(Service):
         """Save file content."""
         record = self.get_record(id_, identity, "create_files")
 
+        if file_key not in record.files:
+            return None
+
         self.run_components(
             "set_file_content",
             identity,
@@ -235,6 +251,9 @@ class FileService(Service):
     def get_file_content(self, identity, id_, file_key):
         """Retrieve file content."""
         record = self.get_record(id_, identity, "read_files")
+
+        if file_key not in record.files:
+            return None
 
         self.run_components("get_file_content", identity, id_, file_key, record)
 


### PR DESCRIPTION
At the moment when requesting from an endpoint that expects to receive a filename (for example `/api/records/{record_id}/files/{filename}`) and the filename does not exist, it will throw an internal server error, it should gracefully return that the resource does not exist. 

Added error catching when a file is being looked up based on it's `key/filename `, if a key error is raised it will return a 404 error to the user.

closes https://github.com/inveniosoftware/invenio-records-resources/issues/347