### PR TITLE
custom fields: simplify implementation of multiple values (list)

### DIFF
--- a/invenio_records_resources/services/custom_fields/__init__.py
+++ b/invenio_records_resources/services/custom_fields/__init__.py
@@ -7,15 +7,15 @@
 
 """Custom Fields for InvenioRDM."""
 
-from .base import BaseCF, ListBaseCF
+from .base import BaseCF, BaseListCF
 from .schema import CustomFieldsSchema, CustomFieldsSchemaUI
 from .text import KeywordCF, TextCF
 
 __all__ = (
     "BaseCF",
+    "BaseListCF",
     "CustomFieldsSchema",
     "CustomFieldsSchemaUI",
     "KeywordCF",
-    "ListBaseCF",
     "TextCF",
 )

--- a/invenio_records_resources/services/custom_fields/base.py
+++ b/invenio_records_resources/services/custom_fields/base.py
@@ -37,7 +37,7 @@ class BaseCF(ABC):
         return self.field
 
 
-class ListBaseCF(BaseCF):
+class BaseListCF(BaseCF):
     """Base Custom Field class."""
 
     def __init__(self, name, multiple=False, **kwargs):

--- a/invenio_records_resources/services/custom_fields/base.py
+++ b/invenio_records_resources/services/custom_fields/base.py
@@ -9,6 +9,8 @@
 
 from abc import ABC, abstractmethod
 
+from marshmallow.fields import List
+
 
 class BaseCF(ABC):
     """Base Custom Field class."""
@@ -40,7 +42,19 @@ class BaseCF(ABC):
 class BaseListCF(BaseCF):
     """Base Custom Field class."""
 
-    def __init__(self, name, multiple=False, **kwargs):
-        """Constructor."""
+    def __init__(self, name, field_cls, multiple=False, **kwargs):
+        """Constructor.
+
+        :param field_cls: The Marshmallow field class to use.
+        :param multiple: If True, the field will be a List field.
+        """
         super().__init__(name, **kwargs)
         self._multiple = multiple
+        self._field_cls = field_cls
+
+    @property
+    def field(self):
+        """Marshmallow field custom fields."""
+        _field = self._field_cls(**self._field_args)
+
+        return List(_field) if self._multiple else _field

--- a/invenio_records_resources/services/custom_fields/text.py
+++ b/invenio_records_resources/services/custom_fields/text.py
@@ -10,10 +10,10 @@
 from marshmallow import fields
 from marshmallow_utils.fields import SanitizedUnicode
 
-from .base import ListBaseCF
+from .base import BaseListCF
 
 
-class KeywordCF(ListBaseCF):
+class KeywordCF(BaseListCF):
     """Keyword custom field."""
 
     @property

--- a/invenio_records_resources/services/custom_fields/text.py
+++ b/invenio_records_resources/services/custom_fields/text.py
@@ -16,18 +16,14 @@ from .base import BaseListCF
 class KeywordCF(BaseListCF):
     """Keyword custom field."""
 
+    def __init__(self, name, **kwargs):
+        """Constructor."""
+        super().__init__(name, field_cls=SanitizedUnicode, **kwargs)
+
     @property
     def mapping(self):
         """Return the mapping."""
         return {"type": "keyword"}
-
-    @property
-    def field(self):
-        """Marshmallow field custom fields."""
-        _schema = SanitizedUnicode(**self._field_args)
-        if self._multiple:
-            return fields.List(_schema)
-        return _schema
 
 
 class TextCF(KeywordCF):

--- a/tests/services/custom_fields/test_text_cf.py
+++ b/tests/services/custom_fields/test_text_cf.py
@@ -80,3 +80,15 @@ def test_textcf_mapping():
 
     cf = TextCF("name", use_as_filter=True)
     assert cf.mapping == {"type": "text", "fields": {"keyword": {"type": "keyword"}}}
+
+
+def test_textcf_list():
+    cf = TextCF("name", multiple=True)
+    schema = Schema.from_dict({"test": cf.field})()
+
+    assert schema.load({"test": ["a string", "another string"]}) == {
+        "test": ["a string", "another string"]
+    }
+
+    with pytest.raises(ValidationError):
+        schema.load({"test": "a string"})


### PR DESCRIPTION
- closes #386 

This enables removing duplicated code. See #387, where both date fields need to reimplement the logic of `if multiple...`. Now it gets delegated to the `BaseListCF` class.