### PR TITLE
services: implement file fetching from external storage

### DIFF
--- a/invenio_records_resources/config.py
+++ b/invenio_records_resources/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2022 CERN.
 # Copyright (C) 2020 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
@@ -12,3 +12,9 @@
 SITE_UI_URL = "https://127.0.0.1:5000"
 
 SITE_API_URL = "https://127.0.0.1:5000/api"
+
+RECORDS_RESOURCES_FILES_ALLOWED_DOMAINS = []
+"""Explicitly allowed domains for external file fetching.
+
+Only file URLs from these domains will be allowed to be fetched.
+"""

--- a/invenio_records_resources/records/jsonschemas/definitions-v1.0.0.json
+++ b/invenio_records_resources/records/jsonschemas/definitions-v1.0.0.json
@@ -12,6 +12,7 @@
       }
     }
   },
+
   "identifier": {
     "description": "An identifier.",
     "type": "string"
@@ -29,14 +30,53 @@
       }
     }
   },
+  "file": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A file object.",
+    "properties": {
+      "version_id": {
+        "description": "Object version ID.",
+        "type": "string"
+      },
+      "bucket_id": {
+        "description": "Object verison bucket ID.",
+        "type": "string"
+      },
+      "mimetype": {
+        "description": "File MIMEType.",
+        "type": "string"
+      },
+      "uri": {
+        "description": "File URI.",
+        "type": "string"
+      },
+      "storage_class": {
+        "description": "File storage class.",
+        "type": "string"
+      },
+      "checksum": {
+        "description": "Checksum of the file.",
+        "type": "string"
+      },
+      "size": {
+        "description": "Size of the file in bytes.",
+        "type": "number"
+      },
+      "key": {
+        "description": "Key (filename) of the file.",
+        "type": "string"
+      },
+      "file_id": {
+        "$ref": "local://definitions-v1.0.0.json#/identifier"
+      }
+    }
+  },
   "internal-pid": {
     "type": "object",
     "description": "An internal persistent identifier object.",
     "additionalProperties": false,
-    "required": [
-      "pk",
-      "status"
-    ],
+    "required": ["pk", "status"],
     "properties": {
       "pk": {
         "description": "Primary key of the PID object.",
@@ -45,13 +85,7 @@
       "status": {
         "description": "The status of the PID (from Invenio-PIDStore).",
         "type": "string",
-        "enum": [
-          "N",
-          "K",
-          "R",
-          "M",
-          "D"
-        ]
+        "enum": ["N", "K", "R", "M", "D"]
       },
       "pid_type": {
         "description": "The type of the persistent identifier.",

--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -40,3 +40,7 @@ class QuerystringValidationError(ValidationError):
     """Error thrown when there is an issue with the querystring."""
 
     pass
+
+
+class TransferException(Exception):
+    """File transfer exception."""

--- a/invenio_records_resources/services/files/components/metadata.py
+++ b/invenio_records_resources/services/files/components/metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 CERN.
+# Copyright (C) 2021-2022 CERN.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -10,9 +10,8 @@
 
 from copy import deepcopy
 
-from invenio_files_rest.models import ObjectVersion
-
 from ..schema import InitFileSchema
+from ..transfer import Transfer
 from .base import FileServiceComponent
 
 
@@ -25,17 +24,18 @@ class FileMetadataComponent(FileServiceComponent):
         validated_data = schema.load(data)
         for file_metadata in validated_data:
             temporary_obj = deepcopy(file_metadata)
-            record.files.create(temporary_obj.pop("key"), data=temporary_obj)
+            file_type = temporary_obj.pop("storage_class", None)
+            transfer = Transfer.get_transfer(
+                file_type, service=self.service, uow=self.uow
+            )
+            _ = transfer.init_file(record, temporary_obj)
 
     def update_file_metadata(self, identity, id, file_key, record, data):
         """Update file metadata handler."""
+        # FIXME: move this call to a transfer call
         record.files.update(file_key, data=data)
 
     # TODO: `commit_file` might vary based on your storage backend (e.g. S3)
     def commit_file(self, identity, id, file_key, record):
         """Commit file handler."""
-        # TODO: Add other checks here (e.g. verify checksum, S3 upload)
-        file_obj = ObjectVersion.get(record.bucket.id, file_key)
-        if not file_obj:
-            raise Exception(f"File with key {file_key} not uploaded yet.")
-        record.files[file_key] = file_obj
+        Transfer.commit_file(record, file_key)

--- a/invenio_records_resources/services/files/generators.py
+++ b/invenio_records_resources/services/files/generators.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""File permissions generators."""
+
+
+from invenio_access.permissions import any_user, system_process
+from invenio_records_permissions.generators import Generator
+from invenio_search.engine import dsl
+
+from .transfer import TransferType
+
+
+class AnyUserIfFileIsLocal(Generator):
+    """Allows any user."""
+
+    def needs(self, **kwargs):
+        """Enabling Needs."""
+        record = kwargs["record"]
+        file_key = kwargs.get("file_key")
+        is_file_local = True
+        if file_key:
+            file_record = record.files.get(file_key)
+            # file_record __bool__ returns false for `if file_record`
+            file = file_record.file if file_record is not None else None
+            is_file_local = not file or file.storage_class == TransferType.LOCAL
+        else:
+            file_records = record.files.entries
+            for file_record in file_records:
+                file = file_record.file
+                if file and file.storage_class != TransferType.LOCAL:
+                    is_file_local = False
+                    break
+
+        if is_file_local:
+            return [any_user]
+        else:
+            return [system_process]
+
+    def query_filter(self, **kwargs):
+        """Match all in search."""
+        return dsl.Q("match_all")

--- a/invenio_records_resources/services/files/tasks.py
+++ b/invenio_records_resources/services/files/tasks.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Files tasks."""
+
+import requests
+from celery import shared_task
+from invenio_access.permissions import system_identity
+
+from ...proxies import current_service_registry
+
+
+@shared_task(ignore_result=True)
+def fetch_file(service_id, record_id, file_key):
+    """Fetch file from external storage."""
+    service = current_service_registry.get(service_id)
+    file_record = service.read_file_metadata(system_identity, record_id, file_key)
+    source_url = file_record.data["uri"]
+    # download file
+    with requests.get(source_url, stream=True) as response:
+        # save file
+        service.set_file_content(
+            system_identity,
+            record_id,
+            file_key,
+            response.raw,  # has read method
+        )
+        # commit file
+        service.commit_file(system_identity, record_id, file_key)

--- a/invenio_records_resources/services/files/transfer.py
+++ b/invenio_records_resources/services/files/transfer.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Files transfer."""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+from invenio_db import db
+from invenio_files_rest.errors import FileSizeError
+
+from ..errors import TransferException
+from ..uow import TaskOp
+from .tasks import fetch_file
+
+
+class TransferType(str, Enum):
+    """File type, it inherits from str to be JSON serializable.
+
+    LOCAL represents a file that is stored locally in the instance's storage.
+    FETCH represents a file that needs to be fetched from an external storage
+             and saved locally.
+    REMOTE represents a file that is stored externally and is linked to the record.
+    """
+
+    LOCAL = "L"
+    FETCH = "F"
+    REMOTE = "R"
+
+    def __eq__(self, other):
+        """Equality test."""
+        return self.value == other
+
+    def __str__(self):
+        """Return its value."""
+        return self.value
+
+
+class BaseTransfer(ABC):
+    """Local transfer."""
+
+    def __init__(self, type, service=None, uow=None):
+        """Constructor."""
+        self.type = type
+        self.service = service
+        self.uow = uow
+
+    @abstractmethod
+    def init_file(self, record, file_metadata):
+        """Initialize a file."""
+        pass
+
+    def set_file_content(self, record, file, file_key, stream, content_length):
+        """Set file content."""
+        bucket = record.bucket
+        size_limit = bucket.size_limit
+        if content_length and size_limit and content_length > size_limit:
+            desc = (
+                "File size limit exceeded."
+                if isinstance(size_limit, int)
+                else size_limit.reason
+            )
+            raise FileSizeError(description=desc)
+
+        record.files.create_obj(
+            file_key, stream, size=content_length, size_limit=size_limit
+        )
+
+    def commit_file(self, record, file_key):
+        """Commit a file."""
+        # fetch files can be committed, its up to permissions to decide by who
+        # e.g. system, since its the one downloading the file
+        record.files.commit(file_key)
+
+    # @abstractmethod
+    # def read_file_content(self, record, file_metadata):
+    #     """Read a file content."""
+    #     pass
+
+
+class LocalTransfer(BaseTransfer):
+    """Local transfer."""
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        super().__init__(TransferType.LOCAL, **kwargs)
+
+    def init_file(self, record, file_metadata):
+        """Initialize a file."""
+        uri = file_metadata.pop("uri", None)
+        if uri:
+            raise Exception("Cannot set URI for local files.")
+
+        file = record.files.create(key=file_metadata.pop("key"), data=file_metadata)
+
+        return file
+
+    def set_file_content(self, record, file, file_key, stream, content_length):
+        """Set file content."""
+        if file:
+            raise TransferException(f'File with key "{file_key}" is committed.')
+
+        super().set_file_content(record, file, file_key, stream, content_length)
+
+
+class FetchTransfer(BaseTransfer):
+    """Fetch transfer."""
+
+    def __init__(self, **kwargs):
+        """Constructor."""
+        super().__init__(TransferType.FETCH, **kwargs)
+
+    def init_file(self, record, file_metadata):
+        """Initialize a file."""
+        uri = file_metadata.pop("uri", None)
+        if not uri:
+            raise Exception("URI is required for fetch files.")
+
+        obj_kwargs = {
+            "file": {
+                "uri": uri,
+                "storage_class": self.type,
+                "checksum": file_metadata.pop("checksum", None),
+                "size": file_metadata.pop("size", None),
+            }
+        }
+
+        file_key = file_metadata.pop("key")
+        file = record.files.create(
+            key=file_key,
+            data=file_metadata,
+            obj=obj_kwargs,
+        )
+
+        self.uow.register(
+            TaskOp(
+                fetch_file,
+                service_id=self.service.id,
+                record_id=record.pid.pid_value,
+                file_key=file_key,
+            )
+        )
+        return file
+
+
+class Transfer:
+    """Transfer type."""
+
+    @classmethod
+    def get_transfer(cls, file_type, **kwargs):
+        """Get transfer type."""
+        if file_type == TransferType.FETCH:
+            return FetchTransfer(**kwargs)
+        else:  # default to local
+            return LocalTransfer(**kwargs)
+
+    @classmethod
+    def commit_file(cls, record, file_key):
+        """Commit a file."""
+        file = record.files.get(file_key).file
+        transfer = cls.get_transfer(getattr(file, "storage_class", None))
+        # file is not passed since that is the current head of the OV
+        # committing means setting the latest of the bucket (OV.get)
+        transfer.commit_file(record, file_key)

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ invenio_base.api_apps =
     invenio_records_resources = invenio_records_resources:InvenioRecordsResources
 invenio_celery.tasks =
     invenio_records_resources = invenio_records_resources.tasks
+    invenio_records_resources_files = invenio_records_resources.services.files.tasks
 invenio_i18n.translations =
     messages = invenio_records_resources
 invenio_jsonschemas.schemas =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,27 @@ pytest_plugins = ("celery.contrib.pytest",)
 
 
 @pytest.fixture(scope="module")
+def app_config(app_config):
+    """Override pytest-invenio app_config fixture.
+
+    Needed to set the fields on the custom fields schema.
+    """
+    app_config["RECORDS_RESOURCES_FILES_ALLOWED_DOMAINS"] = [
+        "inveniordm.test",
+    ]
+
+    app_config["FILES_REST_STORAGE_CLASS_LIST"] = {
+        "L": "Local",
+        "F": "Fetch",
+        "R": "Remote",
+    }
+
+    app_config["FILES_REST_DEFAULT_STORAGE_CLASS"] = "L"
+
+    return app_config
+
+
+@pytest.fixture(scope="module")
 def extra_entry_points():
     """Extra entry points to load the mock_module features."""
     return {

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -13,6 +13,8 @@
 from invenio_records_permissions import RecordPermissionPolicy
 from invenio_records_permissions.generators import AnyUser, SystemProcess
 
+from invenio_records_resources.services.files.generators import AnyUserIfFileIsLocal
+
 
 class PermissionPolicy(RecordPermissionPolicy):
     """Mock permission policy. All actions allowed."""
@@ -23,6 +25,9 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_update = [AnyUser(), SystemProcess()]
     can_delete = [AnyUser(), SystemProcess()]
     can_create_files = [AnyUser(), SystemProcess()]
+    can_set_content_files = [AnyUserIfFileIsLocal(), SystemProcess()]
+    can_get_content_files = [AnyUserIfFileIsLocal(), SystemProcess()]
+    can_commit_files = [AnyUserIfFileIsLocal(), SystemProcess()]
     can_read_files = [AnyUser(), SystemProcess()]
     can_update_files = [AnyUser(), SystemProcess()]
     can_delete_files = [AnyUser(), SystemProcess()]

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2022 CERN.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,9 +9,45 @@
 """File service tests."""
 
 from io import BytesIO
+from unittest.mock import patch
 
 import pytest
+from invenio_access.permissions import system_identity
 from marshmallow import ValidationError
+
+from invenio_records_resources.services.errors import PermissionDeniedError
+
+#
+# Fixtures
+#
+
+
+@pytest.fixture(scope="module")
+def mock_request():
+    """Patch response raw."""
+    # Mock HTTP request
+    class MockResponse:
+        """Mock response."""
+
+        raw = BytesIO(b"test file content")
+
+    class MockRequest:
+        """Mock request."""
+
+        def __enter__(self):
+            """Mock ctx manager."""
+            return MockResponse()
+
+        def __exit__(self, *args):
+            """Mock ctx manager."""
+            pass
+
+    return MockRequest()
+
+
+#
+# Local files
+#
 
 
 def test_file_flow(file_service, location, example_file_record, identity_simple):
@@ -41,7 +77,6 @@ def test_file_flow(file_service, location, example_file_record, identity_simple)
     # Initialize file saving
     result = file_service.init_files(identity_simple, recid, file_to_initialise)
     assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
-
     # for to_file in to_files:
     content = BytesIO(b"test file content")
     result = file_service.set_file_content(
@@ -62,10 +97,12 @@ def test_file_flow(file_service, location, example_file_record, identity_simple)
     # List files
     result = file_service.list_files(identity_simple, recid)
     assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+    assert result.to_dict()["entries"][0]["storage_class"] == "L"
 
     # Read file metadata
     result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
     assert result.to_dict()["key"] == file_to_initialise[0]["key"]
+    assert result.to_dict()["storage_class"] == "L"
 
     # Retrieve file
     result = file_service.get_file_content(identity_simple, recid, "article.txt")
@@ -113,3 +150,289 @@ def test_init_files(file_service, location, example_file_record, identity_simple
     entry = result.to_dict()["entries"][0]
     assert file_to_initialise[0]["key"] == entry["key"]
     assert file_to_initialise[0]["foo"] == entry["metadata"]["foo"]
+
+
+#
+# External files
+#
+
+
+@patch("invenio_records_resources.services.files.tasks.requests.get")
+def test_external_file_simple_flow(
+    p_response_raw,
+    mock_request,
+    file_service,
+    example_file_record,
+    identity_simple,
+    location,
+):
+    """Test the lifecycle of an external file.
+
+    - Initialize file saving
+    - "Wait for completion by the task"
+    - List files of the record
+    - Read file metadata
+    - Retrieve a file
+    - Delete a file
+    - Delete all remaining files
+    - List should be empty
+    """
+
+    p_response_raw.return_value = mock_request
+
+    recid = example_file_record["id"]
+    file_to_initialise = [
+        {
+            "key": "article.txt",
+            "uri": "https://inveniordm.test/files/article.txt",
+            "storage_class": "F",
+        }
+    ]
+
+    # Initialize file saving
+    result = file_service.init_files(identity_simple, recid, file_to_initialise)
+    assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+
+    # WAIT FOR COMPLETION BY THE TASK
+
+    # List files
+    result = file_service.list_files(identity_simple, recid)
+    assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+
+    # Read file metadata
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "L"  # changed after commit
+
+    # Retrieve file
+    result = file_service.get_file_content(identity_simple, recid, "article.txt")
+    assert result.file_id == "article.txt"
+    with result.get_stream("rb") as stream:
+        assert stream.read() == b"test file content"
+
+    # Delete file
+    result = file_service.delete_file(identity_simple, recid, "article.txt")
+    assert result.file_id == "article.txt"
+
+    # Assert deleted
+    result = file_service.list_files(identity_simple, recid)
+    assert result.entries
+    assert len(list(result.entries)) == 0
+
+    # Delete all remaining files
+    result = file_service.delete_all_files(identity_simple, recid)
+    assert list(result.entries) == []
+
+
+def test_external_file_invalid_url(
+    file_service, example_file_record, identity_simple, location
+):
+    """Test invalid URL as URI."""
+
+    recid = example_file_record["id"]
+    file_to_initialise = [
+        {
+            "key": "article.txt",
+            "uri": "invalid",
+            "storage_class": "F",
+        }
+    ]
+
+    with pytest.raises(ValidationError):
+        file_service.init_files(identity_simple, recid, file_to_initialise)
+
+
+@patch("invenio_records_resources.services.files.tasks.requests.get")
+@patch("invenio_records_resources.services.files.transfer.fetch_file")
+def test_content_and_commit_external_file(
+    p_fetch_file,
+    p_response_raw,
+    mock_request,
+    file_service,
+    example_file_record,
+    identity_simple,
+    location,
+):
+    """
+    - Initialize file, should be fetch (is external). Task is mocked, so it won"t be fetched.
+    - Set content as user (test a /content request) --> 403
+    - Set content as system (test task set content) --> Success
+    - Commit as user (test a /commit request) --> 403
+    - Commit as system (test task commit) --> Success
+    """
+    p_response_raw.return_value = mock_request
+
+    recid = example_file_record["id"]
+    file_to_initialise = [
+        {
+            "key": "article.txt",
+            "uri": "https://inveniordm.test/files/article.txt",
+            "storage_class": "F",
+        }
+    ]
+
+    # Initialize file saving
+    result = file_service.init_files(identity_simple, recid, file_to_initialise)
+    assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+
+    # Check it is still external
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "F"
+
+    # Set content as user
+    content = BytesIO(b"test file content")
+    with pytest.raises(PermissionDeniedError):
+        file_service.set_file_content(
+            identity_simple,
+            recid,
+            file_to_initialise[0]["key"],
+            content,
+            content.getbuffer().nbytes,
+        )
+
+    # Set content as system
+    result = file_service.set_file_content(
+        system_identity,
+        recid,
+        file_to_initialise[0]["key"],
+        content,
+        content.getbuffer().nbytes,
+    )
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "F"  # not commited yet
+
+    # Commit as user
+    with pytest.raises(PermissionDeniedError):
+        file_service.commit_file(identity_simple, recid, "article.txt")
+
+    # Commit as system
+    result = file_service.commit_file(system_identity, recid, "article.txt")
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "L"
+
+
+@patch("invenio_records_resources.services.files.tasks.requests.get")
+@patch("invenio_records_resources.services.files.transfer.fetch_file")
+def test_delete_not_committed_external_file(
+    p_fetch_file,
+    p_response_raw,
+    mock_request,
+    file_service,
+    example_file_record,
+    identity_simple,
+    location,
+):
+    """
+    - Initialize file, should be fetch (is external). Task is mocked, so it won"t be fetched.
+    - Delete --> Success
+    - Set content as system --> Fail (None)
+    - Commit as system --> Fail (None)
+    - Assert deleted
+    """
+    p_response_raw.return_value = mock_request
+
+    recid = example_file_record["id"]
+    file_to_initialise = [
+        {
+            "key": "article.txt",
+            "uri": "https://inveniordm.test/files/article.txt",
+            "storage_class": "F",
+        }
+    ]
+
+    # Initialize file saving
+    result = file_service.init_files(identity_simple, recid, file_to_initialise)
+    assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+
+    # Check it is still external
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "F"
+
+    # Delete file
+    file_service.delete_file(identity_simple, recid, "article.txt")
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    assert result is None
+
+    # Assert deleted
+    result = file_service.list_files(identity_simple, recid)
+    assert result.entries
+    assert len(list(result.entries)) == 0
+
+    # Set content as system
+    content = BytesIO(b"test file content")
+    result = file_service.set_file_content(
+        system_identity,
+        recid,
+        file_to_initialise[0]["key"],
+        content,
+        content.getbuffer().nbytes,
+    )
+    assert result is None
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    assert result is None
+
+    # Commit as system
+    assert file_service.commit_file(system_identity, recid, "article.txt") is None
+
+    # Assert deleted
+    result = file_service.list_files(identity_simple, recid)
+    assert result.entries
+    assert len(list(result.entries)) == 0
+
+
+@patch("invenio_records_resources.services.files.tasks.requests.get")
+@patch("invenio_records_resources.services.files.transfer.fetch_file")
+def test_read_not_committed_external_file(
+    p_fetch_file,
+    p_response_raw,
+    mock_request,
+    file_service,
+    example_file_record,
+    identity_simple,
+    location,
+):
+    """
+    - Initialize file, should be fetch (is external). Task is mocked, so it won"t be fetched.
+    - List and read file metadata --> Success
+    - Retrieve file --> 403
+    """
+    p_response_raw.return_value = mock_request
+
+    recid = example_file_record["id"]
+    file_to_initialise = [
+        {
+            "key": "article.txt",
+            "uri": "https://inveniordm.test/files/article.txt",
+            "storage_class": "F",
+        }
+    ]
+    # Initialize file saving
+    result = file_service.init_files(identity_simple, recid, file_to_initialise)
+    assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+
+    # Check it is still external
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "F"
+
+    # List files
+    result = file_service.list_files(identity_simple, recid)
+    assert result.to_dict()["entries"][0]["key"] == file_to_initialise[0]["key"]
+
+    # Read file metadata
+    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
+    result = result.to_dict()
+    assert result["key"] == file_to_initialise[0]["key"]
+    assert result["storage_class"] == "F"  # changed after commit
+
+    # Retrieve file
+    with pytest.raises(PermissionDeniedError):
+        file_service.get_file_content(identity_simple, recid, "article.txt")


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-records-resources/issues/408
- closes https://github.com/inveniosoftware/invenio-records-resources/issues/410

Now there will be two "workflows" to upload files:
a) if the payload **does not** contain a `uri`/`sotrage_class==E` it goes as before: `init` will create the file record (no object version nor file instance), Then requests to `/content` and `/commit` are needed from the user to get the file in.

b) if the payload **does** contain a `uri`/`sotrage_class==E`, the `init` creates an object version and a file instance, and triggers the task to do a `set_content` and `commit`. Those actions are forbiden by the user.