### PR TITLE
tests: consisten mock service naming

### DIFF
--- a/tests/mock_module/config.py
+++ b/tests/mock_module/config.py
@@ -61,6 +61,7 @@ class ServiceConfig(RecordServiceConfig):
     Needs both configs, with File overwritting the record ones.
     """
 
+    service_id = "mock-records"
     permission_policy_cls = PermissionPolicy
     record_cls = Record
     schema = RecordSchema
@@ -85,6 +86,7 @@ class ServiceWithFilesConfig(ServiceConfig):
 class MockFileServiceConfig(FileServiceConfig):
     """File service configuration."""
 
+    service_id = "mock-files"
     record_cls = RecordWithFiles
     permission_policy_cls = PermissionPolicy
 

--- a/tests/resources/test_files_resource.py
+++ b/tests/resources/test_files_resource.py
@@ -55,8 +55,8 @@ def base_app(
     base_app.register_blueprint(file_resource.as_blueprint())
     base_app.register_blueprint(disabled_file_upload_resource.as_blueprint())
     registry = base_app.extensions["invenio-records-resources"].registry
-    registry.register(service, service_id="mock-records-service")
-    registry.register(file_service, service_id="mock-files-service")
+    registry.register(service, service_id="mock-records")
+    registry.register(file_service, service_id="mock-files")
     yield base_app
 
 

--- a/tests/services/files/conftest.py
+++ b/tests/services/files/conftest.py
@@ -31,8 +31,8 @@ def service():
 def base_app(base_app, service, file_service):
     """Application factory fixture."""
     registry = base_app.extensions["invenio-records-resources"].registry
-    registry.register(service, service_id="mock-records-service")
-    registry.register(file_service, service_id="mock-files-service")
+    registry.register(service, service_id="mock-records")
+    registry.register(file_service, service_id="mock-files")
     yield base_app
 
 

--- a/tests/services/test_service_relation_propagation.py
+++ b/tests/services/test_service_relation_propagation.py
@@ -52,7 +52,7 @@ def service_wrel(appctx):
         """Record cls config."""
 
         record_cls = RecordWithRelations
-        relations = {"records": ["metadata.inner_record"]}
+        relations = {"mock-records": ["metadata.inner_record"]}
 
         components = ServiceConfigBase.components + [RelationsComponent]
 


### PR DESCRIPTION
Fixes mock service naming, as per convention (_record type, without the `-service`_). 