### PR TITLE
Bulk indexing for `rebuild_index`

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -464,11 +464,8 @@ class RecordService(Service):
 
         Note: Skips (soft) deleted records.
         """
-        for rec_meta in self.record_cls.model_cls.query.all():
-            rec = self.record_cls(rec_meta.data, model=rec_meta)
-
-            if not rec.is_deleted:
-                self.indexer.index(rec)
+        records = self.record_cls.model_cls.query.filter_by(is_deleted=False).all()
+        self.indexer.bulk_index([rec.id for rec in records])
 
         return True
 

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -54,10 +54,7 @@ class RecordService(Service):
 
     def record_to_index(self, record):
         """Function used to map a record to an index."""
-        # We are returning "_doc" as document type as recommended by
-        # the search engine documentation. In v8
-        # document types will have been completely removed.
-        return record.index._name, "_doc"
+        return record.index._name
 
     @property
     def schema(self):


### PR DESCRIPTION
Make the `service.rebuild_index` method use bulk indexing rather than indexing each item individually.