### PR TITLE
Fix "size" field missing on empty files

### DIFF
--- a/invenio_records_resources/services/files/schema.py
+++ b/invenio_records_resources/services/files/schema.py
@@ -95,7 +95,7 @@ class InitFileSchema(Schema):
             fields = ["checksum", "size"]
             for field in fields:
                 value = getattr(data.file, field, None)
-                if value:
+                if value is not None:
                     data[field] = value
 
         return data


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2032

This PR addresses the issue that empty files (with size 0) blow up record landing pages with an error message stating `jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'size'`.

I have a feeling that there's a better way of doing this that involves the [`schema.fields_from_file_obj`](https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/services/files/schema.py#L77), but I'll have to check some more.
Potentially it also has to do with 0 being the "null" value for integers in the database model?