### PR TITLE
Add new `FileKeyNotFoundError`

### DIFF
--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -33,6 +33,7 @@ from werkzeug.routing import BuildError
 from ..errors import validation_error_to_list_errors
 from ..services.errors import (
     FacetNotFoundError,
+    FileKeyNotFoundError,
     PermissionDeniedError,
     QuerystringValidationError,
     RevisionIdMismatchError,
@@ -156,6 +157,12 @@ class ErrorHandlersMixin:
             lambda e: HTTPJSONException(
                 code=404,
                 description=f"Facet {e.vocabulary_id} not found.",
+            )
+        ),
+        FileKeyNotFoundError: create_error_handler(
+            lambda e: HTTPJSONException(
+                code=404,
+                description=str(e),
             )
         ),
         JSONDecodeError: create_error_handler(

--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -126,9 +126,6 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.view_args["key"],
         )
 
-        if item is None:
-            abort(404)
-
         return item.to_dict(), 200
 
     @request_view_args
@@ -142,9 +139,6 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.view_args["key"],
             resource_requestctx.data or {},
         )
-
-        if item is None:
-            abort(404)
 
         return item.to_dict(), 200
 
@@ -178,9 +172,6 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.view_args["pid_value"],
             resource_requestctx.view_args["key"],
         )
-
-        if item is None:
-            abort(404)
 
         # emit file download stats event
         obj = item._file.object_version
@@ -234,8 +225,5 @@ class FileResource(ErrorHandlersMixin, Resource):
             resource_requestctx.data["request_stream"],
             content_length=resource_requestctx.data["request_content_length"],
         )
-
-        if item is None:
-            abort(404)
 
         return item.to_dict(), 200

--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -55,3 +55,17 @@ class FacetNotFoundError(Exception):
         """Initialise error."""
         self.vocabulary_id = vocabulary_id
         super().__init__(_("Facet {vocab} not found.").format(vocab=vocabulary_id))
+
+
+class FileKeyNotFoundError(Exception):
+    """Error denoting that a record doesn't have a certain file."""
+
+    def __init__(self, recid, file_key):
+        """Constructor."""
+        super().__init__(
+            _("Record '{recid}' has no file '{file_key}'.").format(
+                recid=recid, file_key=file_key
+            )
+        )
+        self.recid = recid
+        self.file_key = file_key

--- a/invenio_records_resources/services/files/tasks.py
+++ b/invenio_records_resources/services/files/tasks.py
@@ -10,26 +10,32 @@
 
 import requests
 from celery import shared_task
+from flask import current_app
 from invenio_access.permissions import system_identity
 
 from ...proxies import current_service_registry
+from ...services.errors import FileKeyNotFoundError
 
 
 @shared_task(ignore_result=True)
 def fetch_file(service_id, record_id, file_key):
     """Fetch file from external storage."""
-    service = current_service_registry.get(service_id)
-    file_record = service.read_file_metadata(system_identity, record_id, file_key)
-    source_url = file_record.data["uri"]
-    # download file
-    # verify=True for self signed certificates by default
-    with requests.get(source_url, stream=True, allow_redirects=True) as response:
-        # save file
-        service.set_file_content(
-            system_identity,
-            record_id,
-            file_key,
-            response.raw,  # has read method
-        )
-        # commit file
-        service.commit_file(system_identity, record_id, file_key)
+    try:
+        service = current_service_registry.get(service_id)
+        file_record = service.read_file_metadata(system_identity, record_id, file_key)
+        source_url = file_record.data["uri"]
+        # download file
+        # verify=True for self signed certificates by default
+        with requests.get(source_url, stream=True, allow_redirects=True) as response:
+            # save file
+            service.set_file_content(
+                system_identity,
+                record_id,
+                file_key,
+                response.raw,  # has read method
+            )
+            # commit file
+            service.commit_file(system_identity, record_id, file_key)
+
+    except FileKeyNotFoundError as e:
+        current_app.logger.error(e)

--- a/invenio_records_resources/tasks.py
+++ b/invenio_records_resources/tasks.py
@@ -17,13 +17,18 @@ from invenio_indexer.proxies import current_indexer_registry
 from invenio_indexer.tasks import process_bulk_queue
 
 from .proxies import current_notifications_registry, current_service_registry
+from .services.errors import FileKeyNotFoundError
 
 
 @shared_task(ignore_result=True)
 def extract_file_metadata(service_id, record_id, file_key):
     """Process file."""
-    service = current_service_registry.get(service_id)
-    service.extract_file_metadata(system_identity, record_id, file_key)
+    try:
+        service = current_service_registry.get(service_id)
+        service.extract_file_metadata(system_identity, record_id, file_key)
+
+    except FileKeyNotFoundError as e:
+        current_app.logger.error(e)
 
 
 @shared_task(ignore_result=True)

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -15,7 +15,10 @@ import pytest
 from invenio_access.permissions import system_identity
 from marshmallow import ValidationError
 
-from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_records_resources.services.errors import (
+    FileKeyNotFoundError,
+    PermissionDeniedError,
+)
 
 #
 # Fixtures
@@ -364,8 +367,8 @@ def test_delete_not_committed_external_file(
 
     # Delete file
     file_service.delete_file(identity_simple, recid, "article.txt")
-    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
-    assert result is None
+    with pytest.raises(FileKeyNotFoundError):
+        result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
 
     # Assert deleted
     result = file_service.list_files(identity_simple, recid)
@@ -374,19 +377,21 @@ def test_delete_not_committed_external_file(
 
     # Set content as system
     content = BytesIO(b"test file content")
-    result = file_service.set_file_content(
-        system_identity,
-        recid,
-        file_to_initialise[0]["key"],
-        content,
-        content.getbuffer().nbytes,
-    )
-    assert result is None
-    result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
-    assert result is None
+    with pytest.raises(FileKeyNotFoundError):
+        result = file_service.set_file_content(
+            system_identity,
+            recid,
+            file_to_initialise[0]["key"],
+            content,
+            content.getbuffer().nbytes,
+        )
+
+    with pytest.raises(FileKeyNotFoundError):
+        result = file_service.read_file_metadata(identity_simple, recid, "article.txt")
 
     # Commit as system
-    assert file_service.commit_file(system_identity, recid, "article.txt") is None
+    with pytest.raises(FileKeyNotFoundError):
+        assert file_service.commit_file(system_identity, recid, "article.txt")
 
     # Assert deleted
     result = file_service.list_files(identity_simple, recid)


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1998

This PR introduces a new custom error type: `FileKeyNotFoundError` to denote when the service was trying to access a non-existing file key for a record.