### PR TITLE
Expandable fields: Skip expansion if the value or service is None

### DIFF
--- a/invenio_records_resources/services/records/results.py
+++ b/invenio_records_resources/services/records/results.py
@@ -344,7 +344,7 @@ class FieldsResolver:
 
         :params expandable_fields: list of ExpandableField obj.
         """
-        self._fields = expandable_fields
+        self._fields = expandable_fields or []
 
     def _collect_values(self, hits):
         """Collect all field values to be expanded."""
@@ -356,8 +356,10 @@ class FieldsResolver:
                 except KeyError:
                     continue
                 else:
-                    # value is not None
                     v, service = field.get_value_service(value)
+                    if v is None or service is None:
+                        continue
+
                     field.add_service_value(service, v)
                     # collect values (ids) and group by service e.g.:
                     # service_1: (13, 4),
@@ -421,9 +423,13 @@ class FieldsResolver:
             else:
                 # value is not None
                 v, service = field.get_value_service(value)
+                if v is None or service is None:
+                    continue
+
                 resolved_rec = field.get_dereferenced_record(service, v)
                 if not resolved_rec:
                     continue
+
                 output = field.pick(identity, resolved_rec)
 
                 # transform field name (potentially dotted) to nested dicts


### PR DESCRIPTION
Some entities are abstract and not backed by a service, like system roles.

It might be however that we encounter such entities during expansion, among others.
One such case is the expansion process for access grants, which allows the referenced entities to be users (:heavy_check_mark: ), roles (:heavy_check_mark:) or system roles (:x:).

This PR chooses to ignore/skip entities that don't have a service with which to resolve them, because that's simpler than adding code in other places that checks for entity types explicitly before trying to dump result lists with expansion on.