### PR TITLE
params: refactored sort fields computation.

### DIFF
--- a/invenio_records_resources/services/records/params/sort.py
+++ b/invenio_records_resources/services/records/params/sort.py
@@ -31,8 +31,13 @@ class SortParam(ParamInterpreter):
 
     def apply(self, identity, search, params):
         """Evaluate the sort parameter on the search."""
-        options = self.config.sort_options
+        fields = self._compute_sort_fields(params)
 
+        return search.sort(*fields)
+
+    def _compute_sort_fields(self, params):
+        """Compute sort fields."""
+        options = self.config.sort_options
         if "sort" not in params:
             params["sort"] = self._default_sort(params, options)
 
@@ -42,5 +47,4 @@ class SortParam(ParamInterpreter):
         sort = options.get(params["sort"])
         if sort is None:
             raise ValidationError(f"Invalid sort option '{params['sort']}'.")
-
-        return search.sort(*sort["fields"])
+        return sort["fields"]

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -23,7 +23,13 @@ from invenio_records_resources.services.errors import PermissionDeniedError
 
 from ..base import LinksTemplate, Service
 from ..errors import RevisionIdMismatchError
-from ..uow import RecordCommitOp, RecordDeleteOp, unit_of_work
+from ..uow import (
+    RecordBulkIndexOp,
+    RecordCommitOp,
+    RecordDeleteOp,
+    RecordIndexOp,
+    unit_of_work,
+)
 from .schema import ServiceSchemaWrapper
 
 
@@ -551,4 +557,47 @@ class RecordService(Service, RecordIndexerMixin):
             )
 
             self.reindex(identity, search_query=search_query)
+        return True
+
+    @unit_of_work()
+    def reindex_latest_first(
+        self, identity, search_preference=None, extra_filter=None, uow=None
+    ):
+        """Reindexes records matching the query filter, prioritizing latest versions.
+
+        Records will be retrieved from search engine and current versions re-indexed first.
+        The latest version of a record is reindexed twice, but we trade that off for the guarantee that it also gets re-indexed first.
+
+        .. warning::
+
+            this service call should only be used during asynchronous calls (e.g. not inside a HTTP request context), since ``search.sync()`` might take some time.
+        """
+        self.require_permission(identity, "manage")
+
+        # Create a search instance with the given filters. We avoid the overhead of executing params interpreters (e.g. aggregations)
+        search = self.create_search(
+            identity,
+            self.record_cls,
+            self.config.search,
+            permission_action="read",
+            extra_filter=extra_filter,
+            preference=search_preference,
+        )
+
+        # Search only latest versions and register them for indexing
+        latest_versions = search.filter("term", **{"versions.is_latest": True}).scan()
+        for res in latest_versions:
+            try:
+                record = self.record_cls.pid.resolve(res.id)
+                uow.register(RecordIndexOp(record, indexer=self.indexer))
+            # Safe check, only re-index records that are resolvable
+            except:
+                continue
+
+        # Search all versions and register them for bulk indexing
+        # source(False): don't return any field, just the metadata
+        all_versions = search.source(False).scan()
+        all_iterable_ids = (res.meta.id for res in all_versions)
+        uow.register(RecordBulkIndexOp(all_iterable_ids, indexer=self.indexer))
+
         return True

--- a/invenio_records_resources/services/uow.py
+++ b/invenio_records_resources/services/uow.py
@@ -164,6 +164,24 @@ class RecordIndexOp(RecordCommitOp):
         pass
 
 
+class RecordBulkIndexOp(Operation):
+    """Record bulk indexing operation."""
+
+    def __init__(self, records_iter, indexer=None):
+        """Initialize the records bulk index operation.
+
+        :param records_iter: iterable of record ids.
+        :param indexer: indexer instance.
+        """
+        self._records_iter = records_iter
+        self._indexer = indexer
+
+    def on_commit(self, uow):
+        """Run the operation."""
+        if self._indexer is not None:
+            self._indexer.bulk_index(self._records_iter)
+
+
 class RecordDeleteOp(Operation):
     """Record removal operation."""
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1398


WHY THIS PR:

- I need to implement a type of `SortParam`, where the `fields` are computed in the same way as the parent except that, in the new interpreter, the fields are always prepended by a new field.
- To avoid code duplication, I refactored the `apply` method to just apply the fields to the search's sort instead of computing the fields + applying them.
- Added a service call to reindex records by the latest version first. 
  - The idea is to speed up the reindexing of the latest versions while the other versions can be done, in bulk, separately. 
- Added a new UOW operation for bulk indexing records, given an iterable of ids (e.g. a generator)