### PR TITLE
[BLOCKED] facets: export CFNestedTermsFacet

### DIFF
--- a/invenio_records_resources/services/records/facets/__init__.py
+++ b/invenio_records_resources/services/records/facets/__init__.py
@@ -8,11 +8,12 @@
 
 """Facets."""
 
-from .facets import CFTermsFacet, NestedTermsFacet, TermsFacet
+from .facets import CFNestedTermsFacet, CFTermsFacet, NestedTermsFacet, TermsFacet
 from .labels import RecordRelationLabels
 from .response import FacetsResponse
 
 __all__ = (
+    "CFNestedTermsFacet",
     "CFTermsFacet",
     "FacetsResponse",
     "NestedTermsFacet",


### PR DESCRIPTION
`CFNestedTermsFacet` cmp is broken, needs to be fixed before being exported and ready to use.