### PR TITLE
services: move reindex latest records to drafts-resources

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -23,13 +23,7 @@ from invenio_records_resources.services.errors import PermissionDeniedError
 
 from ..base import LinksTemplate, Service
 from ..errors import RevisionIdMismatchError
-from ..uow import (
-    RecordBulkIndexOp,
-    RecordCommitOp,
-    RecordDeleteOp,
-    RecordIndexOp,
-    unit_of_work,
-)
+from ..uow import RecordCommitOp, RecordDeleteOp, RecordIndexOp, unit_of_work
 from .schema import ServiceSchemaWrapper
 
 
@@ -557,47 +551,4 @@ class RecordService(Service, RecordIndexerMixin):
             )
 
             self.reindex(identity, search_query=search_query)
-        return True
-
-    @unit_of_work()
-    def reindex_latest_first(
-        self, identity, search_preference=None, extra_filter=None, uow=None
-    ):
-        """Reindexes records matching the query filter, prioritizing latest versions.
-
-        Records will be retrieved from search engine and current versions re-indexed first.
-        The latest version of a record is reindexed twice, but we trade that off for the guarantee that it also gets re-indexed first.
-
-        .. warning::
-
-            this service call should only be used during asynchronous calls (e.g. not inside a HTTP request context), since ``search.sync()`` might take some time.
-        """
-        self.require_permission(identity, "manage")
-
-        # Create a search instance with the given filters. We avoid the overhead of executing params interpreters (e.g. aggregations)
-        search = self.create_search(
-            identity,
-            self.record_cls,
-            self.config.search,
-            permission_action="read",
-            extra_filter=extra_filter,
-            preference=search_preference,
-        )
-
-        # Search only latest versions and register them for indexing
-        latest_versions = search.filter("term", **{"versions.is_latest": True}).scan()
-        for res in latest_versions:
-            try:
-                record = self.record_cls.pid.resolve(res.id)
-                uow.register(RecordIndexOp(record, indexer=self.indexer))
-            # Safe check, only re-index records that are resolvable
-            except:
-                continue
-
-        # Search all versions and register them for bulk indexing
-        # source(False): don't return any field, just the metadata
-        all_versions = search.source(False).scan()
-        all_iterable_ids = (res.meta.id for res in all_versions)
-        uow.register(RecordBulkIndexOp(all_iterable_ids, indexer=self.indexer))
-
         return True


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-records-resources/issues/486

Note: the only usage: https://github.com/inveniosoftware/invenio-rdm-records/blob/0728b74cfd98c92616485b71d259fc224a8a60f9/invenio_rdm_records/requests/user_moderation/actions.py#L32