### PR TITLE
service: display tombstone for deleted record's files

### DIFF
--- a/invenio_records_resources/resources/files/args.py
+++ b/invenio_records_resources/resources/files/args.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Schemas for parameter parsing."""
+
+from flask_resources.parsers import MultiDictSchema
+from marshmallow import Schema, fields
+
+
+class RequestExtraArgsSchema(MultiDictSchema):
+    """Schema for request extra args."""
+
+    include_deleted = fields.Bool()

--- a/invenio_records_resources/resources/files/config.py
+++ b/invenio_records_resources/resources/files/config.py
@@ -11,6 +11,8 @@
 
 from flask_resources import ResourceConfig
 
+from invenio_records_resources.resources.files.args import RequestExtraArgsSchema
+
 
 class FileResourceConfig(ResourceConfig):
     """File resource config."""
@@ -27,3 +29,5 @@ class FileResourceConfig(ResourceConfig):
         "item-commit": "/files/<key>/commit",
         "list-archive": "/files-archive",
     }
+
+    request_extra_args = RequestExtraArgsSchema

--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -69,3 +69,12 @@ class FileKeyNotFoundError(Exception):
         )
         self.recid = recid
         self.file_key = file_key
+
+
+class RecordDeletedException(Exception):
+    """Exception denoting that the record was deleted."""
+
+    def __init__(self, record, result_item=None):
+        """Constructor."""
+        self.record = record
+        self.result_item = result_item

--- a/tests/mock_module/api.py
+++ b/tests/mock_module/api.py
@@ -37,6 +37,34 @@ class FileRecord(FileRecordBase):
     record_cls = None  # is defined below
 
 
+class DeletionStatus:
+    """Mock of Deletion status field."""
+
+    is_deleted = False
+
+
+class Tombstone:
+    """Mock of Tombstone system field."""
+
+    is_visible = True
+    citation_text = "citation text"
+    removal_date = "2023-09-20T08:19:58.431539"
+    removed_by = {"user": "system"}
+    note = "spam"
+
+    def dump(self):
+        """Dump the values."""
+        data = {
+            "note": self.note,
+            "removed_by": self.removed_by,
+            "removal_date": self.removal_date,
+            "citation_text": self.citation_text,
+            "is_visible": self.is_visible,
+        }
+
+        return data
+
+
 class Record(RecordBase):
     """Example record API."""
 
@@ -63,6 +91,10 @@ class Record(RecordBase):
         ]
     )
 
+    deletion_status = DeletionStatus()
+
+    tombstone = Tombstone()
+
 
 class RecordWithRelations(Record):
     """Example record API with relations."""
@@ -87,6 +119,7 @@ class RecordWithFiles(Record):
     files = FilesField(store=False, file_cls=FileRecord)
     bucket_id = ModelField()
     bucket = ModelField(dump=False)
+    is_draft = False
 
 
 FileRecord.record_cls = RecordWithFiles

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -31,3 +31,4 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_read_files = [AnyUser(), SystemProcess()]
     can_update_files = [AnyUser(), SystemProcess()]
     can_delete_files = [AnyUser(), SystemProcess()]
+    can_read_deleted_files = [SystemProcess()]


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1479

The following endpoints display the tombstone page:
- `api/records/<pid>/files`
- `api/records/<pid>/files/<key>`
- `api/records/<pid>/media-files`
- `api/records/<pid>/files/<key>/content`
- `api/records/<pid>/files-archive
`