### PR TITLE
models: fix record file indices

### DIFF
--- a/invenio_records_resources/records/models.py
+++ b/invenio_records_resources/records/models.py
@@ -34,6 +34,7 @@ class FileRecordModelMixin:
             UUIDType,
             db.ForeignKey(cls.__record_model_cls__.id, ondelete="RESTRICT"),
             nullable=False,
+            index=True,
         )
 
     @declared_attr
@@ -59,9 +60,10 @@ class FileRecordModelMixin:
     def __table_args__(cls):
         """Table args."""
         return (
+            # To make sure we don't have duplicate keys for record files
             db.Index(
-                f"uidx_{cls.__tablename__}_id_key",
-                "id",
+                f"uidx_{cls.__tablename__}_record_id_key",
+                "record_id",
                 "key",
                 unique=True,
             ),


### PR DESCRIPTION
- Partially addresses https://github.com/inveniosoftware/invenio-rdm-records/issues/1500
- Adds an index on the `record_id` FK column (for faster listing of all record files)
- Fixes the unique index on `(record_id, key)`, to make sure we don't get duplicate file keys on records.