### PR TITLE
files archive: handle broken files

### DIFF
--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -201,8 +201,9 @@ class FileResource(ErrorHandlersMixin, Resource):
             zs = ZipStream(compress_type=ZIP_STORED)
             with ExitStack() as stack:
                 for file_obj in files._results:
-                    fp = stack.enter_context(file_obj.open_stream("rb"))
-                    zs.add(fp, file_obj.key)
+                    if file_obj.file is not None:
+                        fp = stack.enter_context(file_obj.open_stream("rb"))
+                        zs.add(fp, file_obj.key)
                 yield from zs.all_files()
                 yield from zs.finalize()
 


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/471

Affects "Download all" button in the files (and media files) previewer. Downloads an archive with only healthy files