### PR TITLE
facets: provide CombinedTermsFacet to fix #798 [+]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .DS_Store
+
+# VSCode editor
+.vscode/

--- a/invenio_records_resources/services/records/facets/__init__.py
+++ b/invenio_records_resources/services/records/facets/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 CERN.
+# Copyright (C) 2023 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -8,7 +9,7 @@
 
 """Facets."""
 
-from .facets import CFTermsFacet, NestedTermsFacet, TermsFacet
+from .facets import CFTermsFacet, CombinedTermsFacet, NestedTermsFacet, TermsFacet
 from .labels import RecordRelationLabels
 from .response import FacetsResponse
 
@@ -17,5 +18,6 @@ __all__ = (
     "FacetsResponse",
     "NestedTermsFacet",
     "RecordRelationLabels",
+    "CombinedTermsFacet",
     "TermsFacet",
 )

--- a/invenio_records_resources/services/records/facets/response.py
+++ b/invenio_records_resources/services/records/facets/response.py
@@ -47,9 +47,12 @@ class FacetsResponse(dsl.response.Response):
     def _iter_facets(self):
         # _facets_param instance is added to _search by the FacetsParam.apply
         for name, facet in self._facets_param.facets.items():
-            yield name, facet, getattr(
-                self.aggregations, name
-            ), self._facets_param.selected_values.get(name, [])
+            yield (
+                name,
+                facet,
+                getattr(self.aggregations, name),
+                self._facets_param.selected_values.get(name, []),
+            )
 
     @property
     def facets(self):

--- a/tests/mock_module/config.py
+++ b/tests/mock_module/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2021 CERN.
-# Copyright (C) 2020-2021 Northwestern University.
+# Copyright (C) 2020-2023 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -18,8 +18,8 @@ from invenio_records_resources.services.files.links import FileLink
 from invenio_records_resources.services.records.components import FilesComponent
 from invenio_records_resources.services.records.config import SearchOptions
 from invenio_records_resources.services.records.facets import (
+    CombinedTermsFacet,
     NestedTermsFacet,
-    TermsFacet,
 )
 from invenio_records_resources.services.records.links import (
     RecordLink,
@@ -44,9 +44,11 @@ class MockSearchOptions(SearchOptions):
             splitchar="**",
             label="Type",
         ),
-        "subject": TermsFacet(
-            field="metadata.subject",
-            label="Subject",
+        "subjects": CombinedTermsFacet(
+            field="metadata.subjects.scheme",
+            combined_field="metadata.combined_subjects",
+            parents=["SC1", "SC2"],
+            label="Subjects",
         ),
     }
 

--- a/tests/mock_module/mappings/os-v1/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/os-v1/records/record-v1.0.0.json
@@ -21,7 +21,23 @@
               }
             }
           },
-          "subject": {
+          "subjects": {
+            "type": "object",
+            "properties": {
+              "subject": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "scheme": {
+                "type": "keyword"
+              }
+            }
+          },
+          "combined_subjects": {
             "type": "keyword"
           },
           "inner_record": {

--- a/tests/mock_module/mappings/os-v2/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/os-v2/records/record-v1.0.0.json
@@ -21,7 +21,23 @@
               }
             }
           },
-          "subject": {
+          "subjects": {
+            "type": "object",
+            "properties": {
+              "subject": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "scheme": {
+                "type": "keyword"
+              }
+            }
+          },
+          "combined_subjects": {
             "type": "keyword"
           },
           "inner_record": {

--- a/tests/mock_module/mappings/v7/records/record-v1.0.0.json
+++ b/tests/mock_module/mappings/v7/records/record-v1.0.0.json
@@ -21,7 +21,23 @@
               }
             }
           },
-          "subject": {
+          "subjects": {
+            "type": "object",
+            "properties": {
+              "subject": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "scheme": {
+                "type": "keyword"
+              }
+            }
+          },
+          "combined_subjects": {
             "type": "keyword"
           },
           "inner_record": {

--- a/tests/mock_module/schemas.py
+++ b/tests/mock_module/schemas.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2021 CERN.
-# Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2021-2023 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -22,6 +22,13 @@ class TypeSchema(Schema):
 
     type = fields.Str()
     subtype = fields.Str()
+
+
+class SubjectSchema(Schema):
+    """Nested subject schema used for faceting tests."""
+
+    scheme = fields.Str()
+    subject = fields.Str()
 
 
 class ReferencedCreatedBySchema(Schema):
@@ -48,7 +55,8 @@ class MetadataSchema(Schema):
 
     title = fields.Str(required=True, validate=validate.Length(min=3))
     type = fields.Nested(TypeSchema)
-    subject = fields.Str()
+    subjects = fields.List(fields.Nested(SubjectSchema))
+    combined_subjects = fields.List(fields.Str)
     inner_record = fields.Dict()
     # referenced records
     referenced_created_by = fields.Nested(ReferencedCreatedBySchema)

--- a/tests/resources/test_resource_faceting.py
+++ b/tests/resources/test_resource_faceting.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2023 Northwestern University.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -21,8 +21,8 @@ from invenio_records_resources.services import RecordService
 # 2- links are generated
 
 
-@pytest.fixture(scope="module")
-def three_indexed_records(app, identity_simple, search):
+@pytest.fixture()
+def three_indexed_records(app, identity_simple, search_clear):
     # NOTE: search is used (and not search_clear) here because all tests
     #       assume 3 records have been indexed and NO tests in this module
     #       adds/deletes any.
@@ -51,9 +51,9 @@ def test_aggregating(client, headers, three_indexed_records):
     response_aggs = response.json["aggregations"]
 
     expected_aggs = {
-        "subject": {
+        "subjects": {
             "buckets": [],
-            "label": "Subject",
+            "label": "Subjects",
         },
         "type": {
             "label": "Type",
@@ -101,9 +101,9 @@ def test_post_filtering(client, headers, three_indexed_records):
     # Test aggregation is the same
     response_aggs = response.json["aggregations"]
     expected_aggs = {
-        "subject": {
+        "subjects": {
             "buckets": [],
-            "label": "Subject",
+            "label": "Subjects",
         },
         "type": {
             "label": "Type",
@@ -148,6 +148,126 @@ def test_post_filtering(client, headers, three_indexed_records):
     assert set(["Record 1", "Record 2"]) == set(
         [h["metadata"]["title"] for h in response_hits]
     )
+
+
+def test_nested_post_filtering(client, headers, identity_simple, service, search_clear):
+    data = {
+        "metadata": {
+            "title": "SU1 + (SC1, SU2)",
+            "subjects": [
+                {"subject": "SU1"},  # should be ignored in aggregation results
+                {"scheme": "SC1", "subject": "SU2"},
+            ],
+            "combined_subjects": ["SC1::SU2"],
+        },
+    }
+    service.create(identity_simple, data)
+    data = {
+        "metadata": {
+            "title": "(SC1, SU4) + (SC2, SU2)",
+            "subjects": [
+                {"scheme": "SC1", "subject": "SU4"},
+                {"scheme": "SC2", "subject": "SU2"},
+            ],
+            "combined_subjects": ["SC1::SU4", "SC2::SU2"],
+        },
+    }
+    service.create(identity_simple, data)
+    data = {
+        "metadata": {
+            "title": "(SC2, SU3)",
+            "subjects": [
+                {"scheme": "SC2", "subject": "SU3"},
+            ],
+            "combined_subjects": ["SC2::SU3"],
+        },
+    }
+    service.create(identity_simple, data)
+    Record.index.refresh()
+
+    # First scenario
+    # Test that:
+    # - different subjects/subfields but same scheme result in a union post_filter
+    #   (a record that only has 1 of the scheme+subject should be selected)
+    # - hierarchical dependency is enforced (selects for scheme AND subject together)
+    response = client.get("/mocks?subjects=SC1::SU2&subjects=SC1::SU3", headers=headers)
+    resource_aggs = response.json["aggregations"]
+
+    expected_aggs = {
+        "subjects": {
+            "buckets": [
+                {
+                    "doc_count": 2,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "is_selected": True,
+                                "key": "SU2",
+                                "label": "SU2",
+                            },
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "SU4",
+                                "label": "SU4",
+                            },
+                        ]
+                    },
+                    "is_selected": False,  # only selected if SC1 is separately passed
+                    "key": "SC1",
+                    "label": "SC1",
+                },
+                {
+                    "doc_count": 2,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "SU2",
+                                "label": "SU2",
+                            },
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "SU3",
+                                "label": "SU3",
+                            },
+                        ]
+                    },
+                    "is_selected": False,
+                    "key": "SC2",
+                    "label": "SC2",
+                },
+            ],
+            "label": "Subjects",
+        },
+        "type": {
+            "buckets": [],
+            "label": "Type",
+        },
+    }
+    assert expected_aggs == resource_aggs
+    hits = response.json["hits"]["hits"]
+    assert 1 == len(hits)
+    assert "SU1 + (SC1, SU2)" == hits[0]["metadata"]["title"]
+
+    # 2nd scenario
+    # Test that:
+    # - different schemes/fields result in a union post_filter as well
+    #   (a record that only has 1 of the scheme+subject should be selected)
+    response = client.get("/mocks?subjects=SC1::SU1&subjects=SC2::SU3", headers=headers)
+    resource_aggs = response.json["aggregations"]
+
+    # Reformat expected_aggs
+    inner = expected_aggs["subjects"]["buckets"][0]["inner"]
+    inner["buckets"][0]["is_selected"] = False
+    expected_aggs["subjects"]["buckets"][1]["inner"]["buckets"][1]["is_selected"] = True
+    assert expected_aggs == resource_aggs
+    hits = response.json["hits"]["hits"]
+    assert 1 == len(hits)
+    assert "(SC2, SU3)" == hits[0]["metadata"]["title"]
 
 
 #

--- a/tests/services/test_service_facets.py
+++ b/tests/services/test_service_facets.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2023 Northwestern University.
 # Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
@@ -17,8 +17,8 @@ from mock_module.api import Record
 #
 # Fixtures
 #
-@pytest.fixture(scope="module")
-def records(app, service, identity_simple):
+@pytest.fixture()
+def records(app, service, identity_simple, search_clear):
     """Input data (as coming from the view layer)."""
     items = []
     for idx in range(2):
@@ -26,7 +26,6 @@ def records(app, service, identity_simple):
             "metadata": {
                 "title": f"00{idx}",
                 "type": {"type": f"Foo{idx}", "subtype": f"Bar{idx}"},
-                "subject": f"Subject{idx}",
             },
         }
         items.append(service.create(identity_simple, data))
@@ -38,28 +37,14 @@ def records(app, service, identity_simple):
 # Tests
 #
 def test_facets(app, service, identity_simple, records):
-    """Create a record."""
     # Search it
     res = service.search(identity_simple)
     service_aggs = res.aggregations
 
     expected_aggs = {
-        "subject": {
-            "buckets": [
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject0",
-                    "label": "Subject0",
-                },
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject1",
-                    "label": "Subject1",
-                },
-            ],
-            "label": "Subject",
+        "subjects": {
+            "buckets": [],
+            "label": "Subjects",
         },
         "type": {
             "buckets": [
@@ -99,7 +84,6 @@ def test_facets(app, service, identity_simple, records):
             "label": "Type",
         },
     }
-
     assert expected_aggs == service_aggs
 
 
@@ -109,22 +93,9 @@ def test_facets_post_filtering_union(app, service, identity_simple, records):
     res = service.search(identity_simple, facets={"type": ["Foo0", "Foo1"]})
     service_aggs = res.aggregations
     expected_aggs = {
-        "subject": {
-            "buckets": [
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject0",
-                    "label": "Subject0",
-                },
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject1",
-                    "label": "Subject1",
-                },
-            ],
-            "label": "Subject",
+        "subjects": {
+            "buckets": [],
+            "label": "Subjects",
         },
         "type": {
             "label": "Type",
@@ -174,26 +145,13 @@ def test_facets_post_filtering_intersection(app, service, identity_simple, recor
     """Different facets should result in intersection of results."""
     # No records match both facets
     res = service.search(
-        identity_simple, facets={"type": ["Foo1"], "subject": ["Subject0"]}
+        identity_simple, facets={"type": ["Foo1"], "subjects": ["Subject0"]}
     )
     service_aggs = res.aggregations
     expected_aggs = {
-        "subject": {
-            "buckets": [
-                {
-                    "doc_count": 1,
-                    "is_selected": True,
-                    "key": "Subject0",
-                    "label": "Subject0",
-                },
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject1",
-                    "label": "Subject1",
-                },
-            ],
-            "label": "Subject",
+        "subjects": {
+            "buckets": [],
+            "label": "Subjects",
         },
         "type": {
             "label": "Type",
@@ -244,22 +202,9 @@ def test_facets_post_filtering(app, service, identity_simple, records):
     res = service.search(identity_simple, facets={"type": ["Foo1"]})
     service_aggs = res.aggregations
     expected_aggs = {
-        "subject": {
-            "buckets": [
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject0",
-                    "label": "Subject0",
-                },
-                {
-                    "doc_count": 1,
-                    "is_selected": False,
-                    "key": "Subject1",
-                    "label": "Subject1",
-                },
-            ],
-            "label": "Subject",
+        "subjects": {
+            "buckets": [],
+            "label": "Subjects",
         },
         "type": {
             "label": "Type",
@@ -303,3 +248,100 @@ def test_facets_post_filtering(app, service, identity_simple, records):
     # Test hits are filtered
     assert 1 == len(res)
     assert set(["001"]) == set([h["metadata"]["title"] for h in res])
+
+
+def test_combined_terms_facets(app, service, identity_simple, search_clear):
+    # Create records with nested patterns of interest
+    data = {
+        "metadata": {
+            "title": "SU1 + (SC1, SU2)",
+            "subjects": [
+                {"subject": "SU1"},  # should be ignored in aggregation results
+                {"scheme": "SC1", "subject": "SU2"},
+            ],
+            # Note that you would typically want to have a mechanism in place to
+            # auto-fill this field based on the values in "subjects"
+            "combined_subjects": [
+                "SU1",  # should be ignored in aggregation results
+                "SC1::SU2",
+            ],
+        },
+    }
+    service.create(identity_simple, data)
+    data = {
+        "metadata": {
+            "title": "(SC1, SU2) + (SC2, SU3)",
+            "subjects": [
+                {"scheme": "SC1", "subject": "SU2"},
+                {"scheme": "SC2", "subject": "SU3"},
+            ],
+            "combined_subjects": ["SC1::SU2", "SC2::SU3"],
+        },
+    }
+    service.create(identity_simple, data)
+    data = {
+        "metadata": {
+            "title": "(SC1, SU3)",
+            "subjects": [
+                {"scheme": "SC1", "subject": "SU3"},
+            ],
+            "combined_subjects": ["SC1::SU3"],
+        },
+    }
+    service.create(identity_simple, data)
+    Record.index.refresh()
+
+    # Action
+    res = service.search(identity_simple)
+    service_aggs = res.aggregations
+
+    expected_aggs = {
+        "subjects": {
+            "buckets": [
+                {
+                    "doc_count": 3,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 2,
+                                "is_selected": False,
+                                "key": "SU2",
+                                "label": "SU2",
+                            },
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "SU3",
+                                "label": "SU3",
+                            },
+                        ]
+                    },
+                    "is_selected": False,
+                    "key": "SC1",
+                    "label": "SC1",
+                },
+                {
+                    "doc_count": 1,
+                    "inner": {
+                        "buckets": [
+                            {
+                                "doc_count": 1,
+                                "is_selected": False,
+                                "key": "SU3",
+                                "label": "SU3",
+                            },
+                        ]
+                    },
+                    "is_selected": False,
+                    "key": "SC2",
+                    "label": "SC2",
+                },
+            ],
+            "label": "Subjects",
+        },
+        "type": {
+            "buckets": [],
+            "label": "Type",
+        },
+    }
+    assert expected_aggs == service_aggs


### PR DESCRIPTION
This approach doesn't use 'nested' fields, but instead relies on a
field containing `<parent><split char><child>` to aggregate correctly.

- Alternative to: https://github.com/inveniosoftware/invenio-records-resources/pull/546
- Part of closing: https://github.com/inveniosoftware/invenio-rdm-records/issues/798 
