### PR TITLE
Changed default search type for SuggestQueryParser queries

### DIFF
--- a/invenio_records_resources/services/records/queryparser/suggest.py
+++ b/invenio_records_resources/services/records/queryparser/suggest.py
@@ -51,7 +51,7 @@ class SuggestQueryParser(QueryParser):
     def __init__(self, identity=None, extra_params=None, **kwargs):
         """Constructor."""
         super().__init__(identity=identity, extra_params=extra_params)
-        self.extra_params.setdefault("type", "bool_prefix")
+        self.extra_params.setdefault("type", "best_fields")
 
     def parse(self, query_str):
         """Parse the query."""


### PR DESCRIPTION
### Description

Changes the default OpenSearch search type for the SuggestQueryParser. The current default search type (for the "multi_match" search) is "bool_prefix". This produces unexpected results because it does not differentiate between results based on weighted score. It also does not prioritize, e.g., matches near the beginning of a field or exact matches. I have changed this to "best_fields" which uses a weighted score to prioritize the best matches to the provided query string. The resulting hits are closer to a typical user's expectation. 

Because this is set as a default it can still be overridden when the SuggestQueryParser class is instantiated by passing a different "type" value in the "extra_params" keyword argument.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [X] I've added relevant documentation.
- [X] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [X] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [X] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [X] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [X] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
