### PR TITLE
Query parser: Map search field values

### DIFF
--- a/invenio_records_resources/services/records/queryparser/__init__.py
+++ b/invenio_records_resources/services/records/queryparser/__init__.py
@@ -10,10 +10,11 @@
 
 from .query import QueryParser
 from .suggest import SuggestQueryParser
-from .transformer import SearchFieldTransformer
+from .transformer import FieldValueMapper, SearchFieldTransformer
 
 __all__ = (
+    "FieldValueMapper",
     "QueryParser",
-    "SuggestQueryParser",
     "SearchFieldTransformer",
+    "SuggestQueryParser",
 )

--- a/invenio_records_resources/services/records/queryparser/transformer.py
+++ b/invenio_records_resources/services/records/queryparser/transformer.py
@@ -13,12 +13,33 @@ See https://luqum.readthedocs.io/en/latest/quick_start.html#manipulating for
 how to build your own query tree transformer.
 """
 
-from functools import partial
-
 from invenio_i18n import gettext as _
 from luqum.visitor import TreeTransformer
 
 from invenio_records_resources.services.errors import QuerystringValidationError
+
+
+class FieldValueMapper:
+    """Class used to remap values to new terms."""
+
+    def __init__(self, term_name, word=None, phrase=None):
+        """Initialize field value mapper."""
+        self._term_name = term_name
+        self._word_fun = word
+        self._phrase_fun = phrase
+
+    @property
+    def term_name(self):
+        """Get the term name."""
+        return self._term_name
+
+    def map_word(self, node):
+        """Modify a word node."""
+        return self._word_fun(node) if self._word_fun else node
+
+    def map_phrase(self, node):
+        """Modify a phrase node."""
+        return self._phrase_fun(node) if self._phrase_fun else node
 
 
 class SearchFieldTransformer(TreeTransformer):
@@ -28,12 +49,17 @@ class SearchFieldTransformer(TreeTransformer):
         """Constructor."""
         self._mapping = mapping
         self._allow_list = allow_list
-        super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def visit_search_field(self, node, context):
         """Visit a search field."""
         # Use the node name if not mapped for transformation.
         term_name = self._mapping.get(node.name, node.name)
+        field_value_mapper = None
+
+        if isinstance(term_name, FieldValueMapper):
+            field_value_mapper = term_name
+            term_name = field_value_mapper.term_name
 
         # If a allow list exists, the term must be allowed to be queried.
         if self._allow_list and not term_name in self._allow_list:
@@ -41,8 +67,21 @@ class SearchFieldTransformer(TreeTransformer):
                 _("Invalid search field: {field_name}.").format(field_name=node.name)
             )
 
+        if field_value_mapper:
+            context["field_value_mapper"] = field_value_mapper
+
         # Returns a copy of the node.
         new_node = node.clone_item()
         new_node.name = term_name
         new_node.children = list(self.clone_children(node, new_node, context))
         yield new_node
+
+    def visit_word(self, node, context):
+        """Visit a word term."""
+        mapper = context.get("field_value_mapper")
+        yield node if mapper is None else mapper.map_word(node)
+
+    def visit_phrase(self, node, context):
+        """Visit a phrase term."""
+        mapper = context.get("field_value_mapper")
+        yield node if mapper is None else mapper.map_phrase(node)


### PR DESCRIPTION
### Description

* Adds support for dynamically mapping values in a query to other values, e.g. "communities:blr" to "communities:1234".

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
