### PR TITLE
schema: fix data reference update in pre_load

### DIFF
--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -8,7 +8,7 @@
 # details.
 
 """Record schema."""
-
+from copy import deepcopy
 from datetime import timezone
 
 from marshmallow import Schema, ValidationError, fields, pre_load
@@ -30,12 +30,13 @@ class BaseRecordSchema(Schema):
     revision_id = fields.Integer(dump_only=True)
 
     @pre_load
-    def clean(self, data, **kwargs):
+    def clean(self, input_data, **kwargs):
         """Removes dump_only fields.
 
         Why: We want to allow the output of a Schema dump, to be a valid input
              to a Schema load without causing strange issues.
         """
+        data = deepcopy(input_data)
         for name, field in self.fields.items():
             if field.dump_only:
                 data.pop(name, None)


### PR DESCRIPTION
There seems to an issue with marshmallow that they are not freezing the original data which causes potential modifications leading to an updated copy of the object on subsequent pre/validate/post calls.

https://github.com/marshmallow-code/marshmallow/blob/13a12ad2eed262933770c643febbc46d4905c4c9/src/marshmallow/schema.py#L851-L853

This is work around for that for this specific case https://github.com/inveniosoftware/invenio-communities/pull/1088 where we need to use `pass_original`.