### PR TITLE
services: allow empty files to be uploaded

### DIFF
--- a/invenio_records_resources/config.py
+++ b/invenio_records_resources/config.py
@@ -21,3 +21,6 @@ Only file URLs from these domains will be allowed to be fetched.
 
 RECORDS_RESOURCES_IMAGE_FORMATS = [".jpg", ".jpeg", ".jp2", ".png", ".tif", ".tiff"]
 """Which image formats to extract metadata for."""
+
+RECORDS_RESOURCES_ALLOW_EMPTY_FILES = True
+"""Allow empty files to be uploaded."""


### PR DESCRIPTION
* Added config option to allow empty files to be uploaded.
* Added tests for empty files.
