### PR TITLE
processors: optionally use PyVIPS for image metadata

### DIFF
--- a/invenio_records_resources/services/files/processors/base.py
+++ b/invenio_records_resources/services/files/processors/base.py
@@ -8,7 +8,6 @@
 
 """Files processing engine."""
 
-
 import os
 
 

--- a/invenio_records_resources/services/files/processors/image.py
+++ b/invenio_records_resources/services/files/processors/image.py
@@ -25,36 +25,76 @@ except ImportError:
     # ImageMagick notinstalled
     HAS_IMAGEMAGICK = False
 
+try:
+    import pyvips
+
+    HAS_VIPS = True
+except ModuleNotFoundError:
+    # Python module pyvips not installed
+    HAS_VIPS = False
+except OSError:
+    # Underlying library libvips not installed
+    HAS_VIPS = False
+
 
 class ImageMetadataExtractor(FileProcessor):
     """Basic image metadata extractor."""
 
     def can_process(self, file_record):
         """Images can be processed."""
-        if HAS_IMAGEMAGICK:
+        if HAS_IMAGEMAGICK or HAS_VIPS:
             ext = self.file_extension(file_record).lower()
             return ext in current_app.config["RECORDS_RESOURCES_IMAGE_FORMATS"]
         return False
 
-    def process(self, file_record):
-        """Process the file record.
+    def _process_wand(self, file_record):
+        """Process the file record using Wand.
+
+        Warning: Wand (and ImageMagick) actually reads the entire file in memory to
+        extract the image metadata.
 
         Security: Do not execute ImageMagick inside an HTTP request. Always
         execute via e.g. a Celery task. See
         https://docs.wand-py.org/en/0.6.6/guide/security.html
         """
-        # TODO: gracefully deal with errors.
-        # TODO: security
-        width = -1
-        height = -1
-
-        ext = self.file_extension(file_record)[1:]
-
+        width = height = -1
         with file_record.open_stream("rb") as fp:
-            with Image.ping(file=fp, format=ext) as img:
+            with Image.ping(file=fp) as img:
                 # Get image or first frame of sequence
                 img_or_seq = img if not len(img.sequence) else img.sequence[0]
                 width = img_or_seq.width
                 height = img_or_seq.height
+        return width, height
+
+    def _process_vips(self, file_record):
+        """Process the file record using pyvips."""
+        width = height = -1
+        with file_record.open_stream("rb") as fp:
+
+            def _seek_handler(offset, whence):
+                fp.seek(offset, whence)
+                return fp.tell()
+
+            source = pyvips.SourceCustom()
+            source.on_read(fp.read)
+            source.on_seek(_seek_handler)
+
+            image = pyvips.Image.new_from_source(source, "", access="sequential")
+            width = image.width
+            height = image.height
+        return width, height
+
+    def process(self, file_record):
+        """Process the file record."""
+        width = height = -1
+
+        # Prefer VIPS if available
+        if HAS_VIPS:
+            width, height = self._process_vips(file_record)
+        elif HAS_IMAGEMAGICK:
+            width, height = self._process_wand(file_record)
+
         if width > 0 and height > 0:
-            file_record.metadata.update({"width": width, "height": height})
+            metadata = file_record.metadata or {}
+            metadata.update({"width": width, "height": height})
+            file_record.metadata = metadata


### PR DESCRIPTION
- If `pyvips` (and `libvips` on sysstem) are installed, PyVIPS is used to extract width and height for images.
- Compared to Wand, PyVIPS has the benefit of not loading the entire image in memory to extract width/height metadata for the image (works for multi-layer images also, such as TIFFs and PDFs). See [this gist](https://gist.github.com/slint/55c4ca8e1c59775e73942d4424a62c67) for a small memory analysis.