### PR TITLE
uow: update TaskOp; add TaskRevokeOp

### DIFF
--- a/tests/services/files/test_files_processing.py
+++ b/tests/services/files/test_files_processing.py
@@ -39,12 +39,12 @@ def test_image_meta_extraction(
     file_service.set_file_content(identity_simple, recid, "image.png", image_fp)
 
     # Commit (should send celery task)
-    assert not task.delay.called
+    assert not task.apply_async.called
     file_service.commit_file(identity_simple, recid, "image.png")
-    assert task.delay.called
+    assert task.apply_async.called
 
     # Call task manually
-    extract_file_metadata(*task.delay.call_args[0])
+    extract_file_metadata(*task.apply_async.call_args[1]["args"])
 
     item = file_service.read_file_metadata(identity_simple, recid, "image.png")
     assert item.data["metadata"] == {"width": 1000, "height": 1000}


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-jobs/issues/6 (edited  by @alejandromumo  🥷)

Earlier `TaskOp` used the Celery task delay method, so the signature of init was with respect to delay. However, now we also want to pass execution options which are only possible through `apply_async` (Ref for the signature difference: https://docs.celeryq.dev/en/stable/userguide/calling.html#example).

The `for_apply_async` receives `apply_async` compatible arguments and returns a valid `TaskOp` while using `TaskOp` directly will support the existing signature of `delay`, for backwards compatibility.