### PR TITLE
files: sync metadata on file edit

### DIFF
--- a/invenio_records_resources/records/systemfields/files/manager.py
+++ b/invenio_records_resources/records/systemfields/files/manager.py
@@ -360,7 +360,12 @@ class FilesManager(MutableMapping):
                 if obj_or_key in self:
                     del self[obj_or_key]
             elif operation == "add":
-                self[obj_or_key.key] = obj_or_key
+                f_key = obj_or_key.key
+                rf = src_files[f_key]
+                if rf.metadata is not None:
+                    self[f_key] = obj_or_key, dict(rf)
+                else:
+                    self[f_key] = obj_or_key
 
     @property
     def entries(self):


### PR DESCRIPTION
We calculate image metadata when files are committed, which can happen on record edit as well. 

Right now we only sync the file object version but not the metadata on edit - this PR fixes that.