### PR TITLE
Using lazy_gettext in boot-time translations

### DIFF
--- a/invenio_records_resources/services/records/config.py
+++ b/invenio_records_resources/services/records/config.py
@@ -10,7 +10,7 @@
 
 """Record Service API."""
 
-from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_indexer.api import RecordIndexer
 from invenio_records_permissions.policies.records import RecordPermissionPolicy
 from invenio_search import RecordsSearchV2


### PR DESCRIPTION
### Description

This pull request fixes premature evaluation of i18n strings inside static fields. gettext call, that causes
the evaluation to be performed at boot time, was replaced with gettext_lazy that is performed at
request time. This fixes sort options not being translated when language is changed.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
