### PR TITLE
i18n: Fix untranslated strings in facets

### DIFF
--- a/invenio_records_resources/records/systemfields/entity_reference.py
+++ b/invenio_records_resources/records/systemfields/entity_reference.py
@@ -8,8 +8,7 @@
 
 """Systemfield for managing referenced entities in request."""
 
-from functools import partial
-
+from invenio_i18n import gettext as _
 from invenio_records.systemfields import SystemField
 
 from ...references.entity_resolvers import EntityProxy
@@ -43,7 +42,9 @@ class ReferencedEntityField(SystemField):
 
         # check if the reference is allowed
         if not self._check_reference(instance, obj):
-            raise ValueError(f"Invalid reference for '{self.key}': {obj}")
+            raise ValueError(
+                _("Invalid reference for '%(key)s': %(obj)s", key=self.key, obj=obj)
+            )
 
         # set dictionary key and reset the cache
         self.set_dictkey(instance, obj)

--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -9,11 +9,13 @@
 # details.
 
 """Common Errors handling for Resources."""
+
 from json import JSONDecodeError
 
 import marshmallow as ma
 from flask import jsonify, make_response, request, url_for
 from flask_resources import HTTPJSONException, create_error_handler
+from invenio_i18n import gettext
 from invenio_i18n import lazy_gettext as _
 from invenio_pidstore.errors import (
     PIDAlreadyExists,
@@ -116,56 +118,59 @@ class ErrorHandlersMixin:
         QuerystringValidationError: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="Invalid querystring parameters.",
+                description=_("Invalid querystring parameters."),
             )
         ),
         PermissionDeniedError: create_error_handler(
             HTTPJSONException(
                 code=403,
-                description="Permission denied.",
+                description=_("Permission denied."),
             )
         ),
         RecordPermissionDeniedError: create_error_handler(
             HTTPJSONException(
                 code=403,
-                description="Permission denied.",
+                description=_("Permission denied."),
             )
         ),
         PIDDeletedError: create_error_handler(
             HTTPJSONException(
                 code=410,
-                description="The record has been deleted.",
+                description=_("The record has been deleted."),
             )
         ),
         PIDAlreadyExists: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="The persistent identifier is already registered.",
+                description=_("The persistent identifier is already registered."),
             )
         ),
         PIDDoesNotExistError: create_error_handler(
             HTTPJSONException(
                 code=404,
-                description="The persistent identifier does not exist.",
+                description=_("The persistent identifier does not exist."),
             )
         ),
         PIDUnregistered: create_error_handler(
             HTTPJSONException(
                 code=404,
-                description="The persistent identifier is not registered.",
+                description=_("The persistent identifier is not registered."),
             )
         ),
         PIDRedirectedError: create_pid_redirected_error_handler(),
         NoResultFound: create_error_handler(
             HTTPJSONException(
                 code=404,
-                description="Not found.",
+                description=_("Not found."),
             )
         ),
         FacetNotFoundError: create_error_handler(
             lambda e: HTTPJSONException(
                 code=404,
-                description=f"Facet {e.vocabulary_id} not found.",
+                # using gettext here in order to be able to call the format method
+                description=gettext(
+                    "Facet %(vocabulary_id)s not found.", vocabulary_id=e.vocabulary_id
+                ),
             )
         ),
         FileKeyNotFoundError: create_error_handler(
@@ -177,19 +182,19 @@ class ErrorHandlersMixin:
         JSONDecodeError: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="Unable to decode JSON data in request body.",
+                description=_("Unable to decode JSON data in request body."),
             )
         ),
         InvalidRelationValue: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="Not a valid value.",
+                description=_("Not a valid value."),
             )
         ),
         InvalidCheckValue: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="Not a valid value.",
+                description=_("Not a valid value."),
             )
         ),
         search.exceptions.RequestError: create_error_handler(
@@ -198,13 +203,15 @@ class ErrorHandlersMixin:
         FailedFileUploadException: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="The file upload transfer failed, please try again.",
+                description=_("The file upload transfer failed, please try again."),
             )
         ),
         FilesCountExceededException: create_error_handler(
             HTTPJSONException(
                 code=400,
-                description="Uploading selected files will result in exceeding the max amount per record.",
+                description=_(
+                    "Uploading selected files will result in exceeding the max amount per record."
+                ),
             )
         ),
     }

--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -15,7 +15,6 @@ from json import JSONDecodeError
 import marshmallow as ma
 from flask import jsonify, make_response, request, url_for
 from flask_resources import HTTPJSONException, create_error_handler
-from invenio_i18n import gettext
 from invenio_i18n import lazy_gettext as _
 from invenio_pidstore.errors import (
     PIDAlreadyExists,
@@ -167,8 +166,7 @@ class ErrorHandlersMixin:
         FacetNotFoundError: create_error_handler(
             lambda e: HTTPJSONException(
                 code=404,
-                # using gettext here in order to be able to call the format method
-                description=gettext(
+                description=_(
                     "Facet %(vocabulary_id)s not found.", vocabulary_id=e.vocabulary_id
                 ),
             )

--- a/invenio_records_resources/services/custom_fields/errors.py
+++ b/invenio_records_resources/services/custom_fields/errors.py
@@ -7,8 +7,9 @@
 
 """Custom Fields for InvenioRDM."""
 
-
 from abc import abstractmethod
+
+from invenio_i18n import gettext as _
 
 
 class CustomFieldsException(Exception):
@@ -32,9 +33,10 @@ class InvalidCustomFieldsNamespace(CustomFieldsException):
     @property
     def description(self):
         """Exception's description."""
-        return (
-            f"Namespace {self.given_namespace} is not valid for custom field "
-            f"{self.field_name}."
+        return _(
+            "Namespace %(given_namespace)s is not valid for custom field %(field_name)s.",
+            given_namespace=self.given_namespace,
+            field_name=self.field_name,
         )
 
 
@@ -48,7 +50,10 @@ class CustomFieldsNotConfigured(CustomFieldsException):
     @property
     def description(self):
         """Exception's description."""
-        return f"Custom fields {self.field_names} are not configured."
+        return _(
+            "Custom fields %(field_names)s are not configured.",
+            field_names=self.field_names,
+        )
 
 
 class CustomFieldsInvalidArgument(CustomFieldsException):
@@ -61,6 +66,7 @@ class CustomFieldsInvalidArgument(CustomFieldsException):
     @property
     def description(self):
         """Exception's description."""
-        return (
-            f"Invalid argument {self.arg_name} passed when initializing custom field."
+        return _(
+            "Invalid argument %(arg_name)s passed when initializing custom field.",
+            arg_name=self.arg_name,
         )

--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -30,7 +30,10 @@ class RecordPermissionDeniedError(PermissionDenied):
 class PermissionDeniedError(PermissionDenied):
     """Permission denied error."""
 
-    description = "Permission denied."
+    @property
+    def description(self):
+        """Description."""
+        return _("Permission denied.")
 
 
 class RevisionIdMismatchError(Exception):
@@ -44,9 +47,10 @@ class RevisionIdMismatchError(Exception):
     @property
     def description(self):
         """Exception's description."""
-        return (
-            f"Revision id provided({self.expected_revision_id}) doesn't match "
-            f"record's one({self.record_revision_id})"
+        return _(
+            "Revision id provided(%(expected_revision_id)s) doesn't match record's one(%(record_revision_id)s)",
+            expected_revision_id=self.expected_revision_id,
+            record_revision_id=self.record_revision_id,
         )
 
 
@@ -66,7 +70,7 @@ class FacetNotFoundError(Exception):
     def __init__(self, vocabulary_id):
         """Initialise error."""
         self.vocabulary_id = vocabulary_id
-        super().__init__(_("Facet {vocab} not found.").format(vocab=vocabulary_id))
+        super().__init__(_("Facet %(vocab)s not found.", vocab=vocabulary_id))
 
 
 class FileKeyNotFoundError(Exception):
@@ -75,8 +79,10 @@ class FileKeyNotFoundError(Exception):
     def __init__(self, recid, file_key):
         """Constructor."""
         super().__init__(
-            _("Record '{recid}' has no file '{file_key}'.").format(
-                recid=recid, file_key=file_key
+            _(
+                "Record '%(recid)s' has no file '%(file_key)s'.",
+                recid=recid,
+                file_key=file_key,
             )
         )
         self.recid = recid
@@ -89,8 +95,10 @@ class FailedFileUploadException(Exception):
     def __init__(self, recid, file, file_key):
         """Constructor."""
         super().__init__(
-            _("Record '{recid}' failed to upload file '{file_key}'.").format(
-                recid=recid, file_key=file_key
+            _(
+                "Record '%(recid)s' failed to upload file '%(file_key)s'.",
+                recid=recid,
+                file_key=file_key,
             )
         )
         self.recid = recid

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -10,6 +10,7 @@
 """File Service API."""
 
 from flask import current_app
+from invenio_i18n import gettext as _
 
 from ..base import LinksTemplate, Service
 from ..errors import FailedFileUploadException, FileKeyNotFoundError
@@ -257,10 +258,10 @@ class FileService(Service):
 
         except FailedFileUploadException as e:
             file = e.file
-            current_app.logger.exception(f"File upload transfer failed.")
+            current_app.logger.exception("File upload transfer failed.")
             # we gracefully fail so that uow can commit the cleanup operation in
             # FileContentComponent
-            errors = "File upload transfer failed."
+            errors = _("File upload transfer failed.")
 
         return self.file_result_item(
             self,

--- a/invenio_records_resources/services/records/params/pagination.py
+++ b/invenio_records_resources/services/records/params/pagination.py
@@ -10,6 +10,8 @@
 
 from copy import deepcopy
 
+from invenio_i18n import gettext as _
+
 from ....pagination import Pagination
 from ...errors import QuerystringValidationError
 from .base import ParamInterpreter
@@ -34,6 +36,6 @@ class PaginationParam(ParamInterpreter):
         )
 
         if not p.valid():
-            raise QuerystringValidationError("Invalid pagination parameters.")
+            raise QuerystringValidationError(_("Invalid pagination parameters."))
 
         return search[p.from_idx : p.to_idx]

--- a/invenio_records_resources/services/records/params/querystr.py
+++ b/invenio_records_resources/services/records/params/querystr.py
@@ -8,9 +8,10 @@
 
 """Query parameter interpreter API."""
 
-from ...errors import QuerystringValidationError
-
 # Here for backward compatibility
+from invenio_i18n import gettext as _
+
+from ...errors import QuerystringValidationError
 from ..queryparser import QueryParser, SuggestQueryParser  # noqa
 from .base import ParamInterpreter
 
@@ -25,8 +26,10 @@ class QueryStrParam(ParamInterpreter):
 
         if q_str and suggest_str:
             raise QuerystringValidationError(
-                "You cannot specify both 'q' and 'suggest' parameters at the "
-                "same time."
+                _(
+                    "You cannot specify both 'q' and 'suggest' parameters at the "
+                    "same time."
+                )
             )
 
         query_str = q_str
@@ -35,7 +38,7 @@ class QueryStrParam(ParamInterpreter):
             query_str = suggest_str
             parser_cls = self.config.suggest_parser_cls
             if parser_cls is None:
-                raise QuerystringValidationError("Invalid 'suggest' parameter.")
+                raise QuerystringValidationError(_("Invalid 'suggest' parameter."))
 
         if query_str:
             query = parser_cls(identity).parse(query_str)

--- a/invenio_records_resources/services/records/params/sort.py
+++ b/invenio_records_resources/services/records/params/sort.py
@@ -10,6 +10,7 @@
 
 from copy import deepcopy
 
+from invenio_i18n import gettext as _
 from marshmallow import ValidationError
 
 from .base import ParamInterpreter
@@ -57,5 +58,7 @@ class SortParam(ParamInterpreter):
 
         sort = options.get(params["sort"])
         if sort is None:
-            raise ValidationError(f"Invalid sort option '{params['sort']}'.")
+            raise ValidationError(
+                _("Invalid sort option '%(sort_option)s'.", sort_option=params["sort"])
+            )
         return sort["fields"]

--- a/invenio_records_resources/services/records/queryparser/transformer.py
+++ b/invenio_records_resources/services/records/queryparser/transformer.py
@@ -125,14 +125,12 @@ class SearchFieldTransformer(TreeTransformer):
             # allows, we don't map any query, we allow it "as is"
             if not allows:
                 raise QuerystringValidationError(
-                    _("Invalid search field: {field_name}.").format(
-                        field_name=node.name
-                    )
+                    _("Invalid search field: %(field_name)s.", field_name=node.name)
                 )
         # If a allow list exists, the term must be allowed to be queried.
-        if self._allow_list and not term_name in self._allow_list:
+        if self._allow_list and term_name not in self._allow_list:
             raise QuerystringValidationError(
-                _("Invalid search field: {field_name}.").format(field_name=node.name)
+                _("Invalid search field: %(field_name)s.", field_name=node.name)
             )
 
         if field_value_mapper:

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,22 +89,22 @@ add_ignore = D401
 
 [compile_catalog]
 directory = invenio_records_resources/translations/
-use-fuzzy = True
+use_fuzzy = True
 
 [extract_messages]
 copyright_holder = CERN
 msgid_bugs_address = info@inveniosoftware.org
-mapping-file = babel.ini
-output-file = invenio_records_resources/translations/messages.pot
-add-comments = NOTE
+mapping_file = babel.ini
+output_file = invenio_records_resources/translations/messages.pot
+add_comments = NOTE
 
 [init_catalog]
-input-file = invenio_records_resources/translations/messages.pot
-output-dir = invenio_records_resources/translations/
+input_file = invenio_records_resources/translations/messages.pot
+output_dir = invenio_records_resources/translations/
 
 [update_catalog]
-input-file = invenio_records_resources/translations/messages.pot
-output-dir = invenio_records_resources/translations/
+input_file = invenio_records_resources/translations/messages.pot
+output_dir = invenio_records_resources/translations/
 
 [isort]
 profile=black


### PR DESCRIPTION
### Description

Fix: some strings that could appear inside UI were not marked with gettext/lazy_gettext.

This PR adds lazy_gettext into places where the string is read when invenio is started (static initialization) and gettext elsewhere

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
