### PR TITLE
fix: file upload >100MB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version unreleased
+
+- fix: file upload >100MB
+
 Version 7.0.0 (release 2024-12-09)
 
 - setup: change to reusable workflows


### PR DESCRIPTION
* flask uses now the MAX_CONTENT_LENGTH to restrict file upload. it is
  possible to set the max_content_length per request. so for this request
  it is set to the configured max file size

NOTE:
needs https://github.com/inveniosoftware/invenio-oauth2server/pull/272
