### PR TITLE
files: remove HTTP code from read_content

### DIFF
--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -201,7 +201,7 @@ class FileResource(ErrorHandlersMixin, Resource):
         if obj is not None and emitter is not None:
             emitter(current_app, record=item._record, obj=obj, via_api=True)
 
-        return item.send_file(), 200
+        return item.send_file()
 
     @request_view_args
     def read_archive(self):


### PR DESCRIPTION
* Setting the return code directly hides the return code that ``send_file`` might be issuing, resulting in odd situations when the storage layer returns a 302, i.e. offload download.

---

When an instance uses local storage, eventually [send_file](https://github.com/inveniosoftware/invenio-files-rest/blob/master/invenio_files_rest/helpers.py#L62) gets called and the file is streamed through the application server.

If one uses Invenio-S3,  instead of serving the file directly, the application [issues a redirect](https://github.com/inveniosoftware/invenio-s3/blob/master/invenio_s3/helpers.py#L20) to a short-lived signed URL, relaying the work of streaming the file to the storage server, offloading.

The problem is that send_file itself returns a response with its own response code, etc. The 200 [here](https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/resources/files/resource.py#L204) basically overwrites that response code and the redirect doesn't work.

We don't experience that same behavior with EOS because the redirect is happening at [nginx level](https://github.com/zenodo/zenodo-rdm/blob/master/site/zenodo_rdm/files.py#L74) using X-Accel-Redirect.
