### PR TITLE
Passing more context to permissions and components

### DIFF
--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2020-2021 CERN.
 # Copyright (C) 2020-2021 Northwestern University.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -84,7 +84,7 @@ class FileService(Service):
         action_name = self.config.permission_action_prefix + action_name
         return super().check_permission(identity, action_name, **kwargs)
 
-    def _get_record(self, id_, identity, action, file_key=None):
+    def _get_record(self, id_, identity, action, file_key=None, **kwargs):
         """Get the associated record.
 
         If a ``file_key`` is specified and the record in question doesn't have a file
@@ -102,16 +102,18 @@ class FileService(Service):
         if file_key and file_key not in record.files:
             raise FileKeyNotFoundError(id_, file_key)
 
-        self.require_permission(identity, action, record=record, file_key=file_key)
+        self.require_permission(
+            identity, action, record=record, file_key=file_key, **kwargs
+        )
 
         return record
 
     #
     # High-level API
     #
-    def list_files(self, identity, id_):
+    def list_files(self, identity, id_, **kwargs):
         """List the files of a record."""
-        record = self._get_record(id_, identity, "read_files")
+        record = self._get_record(id_, identity, "read_files", **kwargs)
 
         self.run_components("list_files", id_, identity, record)
 
@@ -125,7 +127,7 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def init_files(self, identity, id_, data, uow=None):
+    def init_files(self, identity, id_, data, uow=None, **kwargs):
         """Initialize the file upload for the record."""
         # validate the input data at the beginning, as we need to check
         # if user has permission for the transfer type that is on
@@ -142,7 +144,11 @@ class FileService(Service):
 
         for created_file in data:
             self.require_permission(
-                identity, "create_files", record=record, file_metadata=created_file
+                identity,
+                "create_files",
+                record=record,
+                file_metadata=created_file,
+                **kwargs,
             )
 
         self.run_components("init_files", identity, id_, record, data, uow=uow)
@@ -157,12 +163,14 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def update_file_metadata(self, identity, id_, file_key, data, uow=None):
+    def update_file_metadata(self, identity, id_, file_key, data, uow=None, **kwargs):
         """Update the metadata of a file.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "create_files", file_key=file_key)
+        record = self._get_record(
+            id_, identity, "create_files", file_key=file_key, data=data, **kwargs
+        )
 
         self.run_components(
             "update_file_metadata", identity, id_, file_key, record, data, uow=uow
@@ -176,12 +184,14 @@ class FileService(Service):
             links_tpl=self.file_links_item_tpl(id_),
         )
 
-    def read_file_metadata(self, identity, id_, file_key):
+    def read_file_metadata(self, identity, id_, file_key, **kwargs):
         """Read the metadata of a file.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "read_files", file_key=file_key)
+        record = self._get_record(
+            id_, identity, "read_files", file_key=file_key, **kwargs
+        )
 
         self.run_components("read_file_metadata", identity, id_, file_key, record)
 
@@ -194,12 +204,14 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def extract_file_metadata(self, identity, id_, file_key, uow=None):
+    def extract_file_metadata(self, identity, id_, file_key, uow=None, **kwargs):
         """Extract metadata from a file and update the file metadata file.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "create_files", file_key=file_key)
+        record = self._get_record(
+            id_, identity, "create_files", file_key=file_key, **kwargs
+        )
         file_record = record.files[file_key]
 
         self.run_components(
@@ -223,12 +235,14 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def commit_file(self, identity, id_, file_key, uow=None):
+    def commit_file(self, identity, id_, file_key, uow=None, **kwargs):
         """Commit a file upload.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "commit_files", file_key=file_key)
+        record = self._get_record(
+            id_, identity, "commit_files", file_key=file_key, **kwargs
+        )
 
         self.run_components("commit_file", identity, id_, file_key, record, uow=uow)
 
@@ -241,12 +255,14 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def delete_file(self, identity, id_, file_key, uow=None):
+    def delete_file(self, identity, id_, file_key, uow=None, **kwargs):
         """Delete a single file.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "delete_files", file_key=file_key)
+        record = self._get_record(
+            id_, identity, "delete_files", file_key=file_key, **kwargs
+        )
         deleted_file = record.files.delete(file_key, remove_rf=True)
 
         self.run_components(
@@ -265,9 +281,9 @@ class FileService(Service):
         )
 
     @unit_of_work()
-    def delete_all_files(self, identity, id_, uow=None):
+    def delete_all_files(self, identity, id_, uow=None, **kwargs):
         """Delete all the files of the record."""
-        record = self._get_record(id_, identity, "delete_files")
+        record = self._get_record(id_, identity, "delete_files", **kwargs)
 
         # We have to separate the gathering of the keys from their deletion
         # because of how record.files is implemented.
@@ -289,13 +305,21 @@ class FileService(Service):
 
     @unit_of_work()
     def set_file_content(
-        self, identity, id_, file_key, stream, content_length=None, uow=None
+        self, identity, id_, file_key, stream, content_length=None, uow=None, **kwargs
     ):
         """Save file content.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "set_content_files", file_key=file_key)
+        record = self._get_record(
+            id_,
+            identity,
+            "set_content_files",
+            file_key=file_key,
+            stream=stream,
+            content_length=content_length,
+            **kwargs,
+        )
         errors = None
         try:
             self.run_components(
@@ -326,12 +350,14 @@ class FileService(Service):
             links_tpl=self.file_links_item_tpl(id_),
         )
 
-    def get_file_content(self, identity, id_, file_key):
+    def get_file_content(self, identity, id_, file_key, **kwargs):
         """Retrieve file content.
 
         :raises FileKeyNotFoundError: If the record has no file for the ``file_key``
         """
-        record = self._get_record(id_, identity, "get_content_files", file_key=file_key)
+        record = self._get_record(
+            id_, identity, "get_content_files", file_key=file_key, **kwargs
+        )
 
         self.run_components("get_file_content", identity, id_, file_key, record)
 

--- a/invenio_records_resources/services/records/components/relations.py
+++ b/invenio_records_resources/services/records/components/relations.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020-2022 CERN.
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -17,7 +18,7 @@ from .base import ServiceComponent
 class RelationsComponent(ServiceComponent):
     """Relations service component."""
 
-    def read(self, identity, record=None):
+    def read(self, identity, record=None, **kwargs):
         """Read record handler."""
         record.relations.dereference()
 


### PR DESCRIPTION
### Description

At CESNET we extend record service in the following ways:

- A community is required when record is created and user has to have a submitter role in that community
- Publishing and similar operations are always performed via dedicated requests, not direct API calls

 In order to do so, we need to extend permission checks so that they not only include record but also create/update data and additional parameters from context.

This pull request:

 - add kwargs to service methods
- passes the kwargs data and additional context to permission checks

This change is 100% backwards compatible and in RDM does not cause any differences in permission handling. This pull request is also similar to [this one](https://github.com/inveniosoftware/invenio-requests/pull/440#issue-2988398019) in invenio-requests, in which @mesemus provided an explanation. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
