### PR TITLE
fix: Raise correct exception if file does not exist

### DIFF
--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -93,10 +93,16 @@ class FileService(Service):
         # FIXME: Remove "registered_only=False" since it breaks access to an
         # unpublished record.
         record = self.record_cls.pid.resolve(id_, registered_only=False)
-        self.require_permission(identity, action, record=record, file_key=file_key)
 
+        # note: we check file existence before checking permissions, as permission
+        # checks may require the file to exist (e.g. IfTransferType permission)
+        # and if it does not exist, will return a permission denied, resulting in 403
+        # status code. By reveresing the order, we can return a more specific
+        # 404 status code.
         if file_key and file_key not in record.files:
             raise FileKeyNotFoundError(id_, file_key)
+
+        self.require_permission(identity, action, record=record, file_key=file_key)
 
         return record
 

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -197,6 +197,17 @@ def test_init_files(file_service, location, example_file_record, identity_simple
     assert second_entry["access"]["hidden"] is True
 
 
+def test_retrieve_non_existing_file(
+    file_service, location, example_file_record, identity_simple, db
+):
+    """Test if accessing a non-existing file raises a correct error."""
+    recid = example_file_record["id"]
+
+    # Retrieve file
+    with pytest.raises(FileKeyNotFoundError):
+        file_service.get_file_content(identity_simple, recid, "does_not_exist.txt")
+
+
 #
 # External fetched files
 #


### PR DESCRIPTION
### Description

This PR changes the order of evaluating permissions and checking file existence inside the file service.

The rationale is that permission checks may require the file to exist (e.g., the `IfTransferType` permission), and if it does not, `PermissionDenied` is currently raised.

The correct behavior is to raise `FileKeyNotFoundError`.

In the previous implementation of permissions in `invenio-app-rdm`, non-existing files were treated as if they existed and were stored locally. That’s why the correct exception was raised—permissions always passed for non-existing files, and the subsequent file existence check returned the proper exception.

I’m hesitant to enforce the semantics where permissions for non-existent files always pass, so I’ve opted to change the order of checks instead, as implemented in this PR.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
