### PR TITLE
Fix EDTFDateStringCF dump/load to support multiple values

### DIFF
--- a/invenio_records_resources/services/custom_fields/date.py
+++ b/invenio_records_resources/services/custom_fields/date.py
@@ -83,8 +83,10 @@ class EDTFDateStringCF(BaseListCF):
         if dates:
             try:
                 if self._multiple:
+                    data[cf_key][self.name] = []
+
                     for date in dates:
-                        data[cf_key][self.name] = self._calculate_date_range(date)
+                        data[cf_key][self.name].append(self._calculate_date_range(date))
                 else:
                     # dates is just one date
                     data[cf_key][self.name] = self._calculate_date_range(dates)
@@ -98,6 +100,9 @@ class EDTFDateStringCF(BaseListCF):
         This supports the case where a field is based on others, both
         custom and non-custom fields.
         """
-        date = record.get(cf_key, {}).pop(self.name, None)
-        if date:
-            record[cf_key][self.name] = date["date"]
+        dates = record.get(cf_key, {}).pop(self.name, None)
+        if dates:
+            if self._multiple:
+                record[cf_key][self.name] = [d["date"] for d in dates]
+            else:
+                record[cf_key][self.name] = dates["date"]

--- a/tests/services/custom_fields/test_date_cf.py
+++ b/tests/services/custom_fields/test_date_cf.py
@@ -88,3 +88,55 @@ def test_edtfdatestring_custom_field_cls_list():
 
     with pytest.raises(CustomFieldsInvalidArgument):
         _ = EDTFDateStringCF("name", field_cls=MyClass, multiple=True)
+
+
+def test_edtfdatestring_multiple_dump():
+    field_name = "test_multiple_edtf"
+    cf = EDTFDateStringCF(field_name, multiple=True)
+
+    # Test loading multiple valid values
+    data = {"custom_fields": {field_name: ["2020-09/2020-10", "2021-01-01"]}}
+    expected_output = {
+        "custom_fields": {
+            field_name: [
+                {
+                    "date": "2020-09/2020-10",
+                    "date_range": {"gte": "2020-09-01", "lte": "2020-10-31"},
+                },
+                {
+                    "date": "2021-01-01",
+                    "date_range": {"gte": "2021-01-01", "lte": "2021-01-01"},
+                },
+            ]
+        }
+    }
+
+    cf.dump(data)
+
+    assert data == expected_output
+
+
+def test_edtfdatestring_multiple_load():
+    field_name = "test_multiple_edtf"
+    cf = EDTFDateStringCF(field_name, multiple=True)
+
+    # Test loading multiple valid values
+    data = {
+        "custom_fields": {
+            field_name: [
+                {
+                    "date": "2020-09/2020-10",
+                    "date_range": {"gte": "2020-09-01", "lte": "2020-10-31"},
+                },
+                {
+                    "date": "2021-01-01",
+                    "date_range": {"gte": "2021-01-01", "lte": "2021-01-01"},
+                },
+            ]
+        }
+    }
+    expected_output = {"custom_fields": {field_name: ["2020-09/2020-10", "2021-01-01"]}}
+
+    cf.load(data)
+
+    assert data == expected_output


### PR DESCRIPTION


### Description

This fixes #634 



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
