### PR TITLE
fix: increase allowed content-length for multipart-upload content

### DIFF
--- a/invenio_records_resources/resources/files/resource.py
+++ b/invenio_records_resources/resources/files/resource.py
@@ -13,6 +13,7 @@
 """Invenio Record File Resources."""
 
 from contextlib import ExitStack
+from functools import wraps
 
 import marshmallow as ma
 from flask import Response, current_app, g, request, stream_with_context
@@ -72,6 +73,7 @@ request_multipart_args = request_parser(
 def set_max_content_length(func):
     """Set max content length."""
 
+    @wraps(func)
     def _wrapper(*args, **kwargs):
         # flask >= 3.1.0 changed the behavior of MAX_CONTENT_LENGTH
         # configuration variable. this is applied now to all requests
@@ -292,6 +294,7 @@ class FileResource(ErrorHandlersMixin, Resource):
 
         return item.to_dict(), 200
 
+    @set_max_content_length
     @request_multipart_args
     @request_stream
     @response_handler()


### PR DESCRIPTION
* Multipart transfers adheres to MAX_CONTENT_LENGTH size limit for each uploaded part content, limiting part size to max. 100 MiB.

* Uploader UI supports much larger part sizes than that (e.g. when S3 storage is in use - it could create 5 GiB chunks)

* We fix this by overriding the default limit, allowing the part size to be the same as FILES_REST_DEFAULT_MAX_FILE_SIZE.
* 
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
