### PR TITLE
fix: removed dependency on PyFilesystem2

### DIFF
--- a/invenio_records_resources/services/files/transfer/base.py
+++ b/invenio_records_resources/services/files/transfer/base.py
@@ -11,7 +11,6 @@
 from abc import ABC
 
 from flask_babel import lazy_gettext as _
-from fs.errors import CreateFailed
 from invenio_files_rest.errors import FileSizeError
 from werkzeug.exceptions import ClientDisconnected
 
@@ -99,7 +98,7 @@ class Transfer(ABC):
             self.record.files.create_obj(
                 self.file_record.key, stream, size=content_length, size_limit=size_limit
             )
-        except (ClientDisconnected, CreateFailed):
+        except (ClientDisconnected, OSError):
             raise TransferException(
                 f'Transfer of File with key "{self.file_record.key}" failed.'
             )


### PR DESCRIPTION
### Description

* PyFilesystem2 seems not to be maintained anymore
* Depends on https://github.com/inveniosoftware/invenio-files-rest/pull/330

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
