### PR TITLE
service: use "read" permission in `read_many`

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -17,7 +17,6 @@ from invenio_records_permissions.api import permission_filter
 from invenio_search import current_search_client
 from invenio_search.engine import dsl
 from kombu import Queue
-from marshmallow import ValidationError
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.local import LocalProxy
 
@@ -428,7 +427,7 @@ class RecordService(Service, RecordIndexerMixin):
             identity=identity,
             record_cls=record_cls or self.record_cls,
             search_opts=search_opts or self.config.search,
-            permission_action="search",
+            permission_action="read",
             preference=preference,
             extra_filter=extra_filter,
             versioning=True,


### PR DESCRIPTION
In most of the `RecordsService.create_search` calls throughout the
codebase, we're passing `permission_action="read"`. This is because
`can_read` is the permission where we describe in each generator's
`Generator.query_filter` the search filtering logic which targets
the individual entities that an `identity` can access, for example
"my records", "records in communities I'm a curator", etc.

The only case where we don't use `read`, is when we use `read_deleted`,
which is usually just stricter version of `read`.

Relying on the `(can_)search` permission is usually wrong, since this is
used to check if someone "can" search, but not "what" they can search.

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3140