### PR TITLE
fix(multipart): recompute full file checksum if no parts are set

### DIFF
--- a/invenio_records_resources/services/files/tasks.py
+++ b/invenio_records_resources/services/files/tasks.py
@@ -87,8 +87,14 @@ def recompute_multipart_checksum_task(file_instance_id):
     try:
         file_instance = FileInstance.query.filter_by(id=file_instance_id).one()
         checksum = file_instance.checksum
-        if not checksum.startswith("multipart:"):
+        if not checksum:
+            file_instance.update_checksum()
+            db.session.add(file_instance)
+            db.session.commit()
             return
+        elif not checksum.startswith("multipart:"):
+            return
+
         # multipart checksum looks like: multipart:<s3 multipart checksum>-part_size
         # s3 multipart checksum is the etag of the multipart object and looks like
         # hex(md5(<md5(part1) + md5(part2) + ...>))-<number of parts>


### PR DESCRIPTION
In our tests (with local file storage), multipart-uploaded files did not have a checksum set at all (it was set to `None`), which caused the task `recompute_multipart_checksum_task()` to fail.

This PR handles the case that the checksum is set to `None` in the task.

However, I'm not sure if that's just symptom treatment, and it would make more sense instead to make sure that every uploaded part's checksum were calculated and stored instead?

Ping @mesemus 