### PR TITLE
feat: Add storage provider for remote files

### DIFF
--- a/invenio_records_resources/config.py
+++ b/invenio_records_resources/config.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2020-2022 CERN.
 # Copyright (C) 2020 Northwestern University.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -34,7 +34,11 @@ RECORDS_RESOURCES_TRANSFERS = [
 ]
 """List of transfer classes to register."""
 
+FILES_REST_STORAGE_FACTORIES = {
+    "R": "invenio_records_resources.records.storage.remote_storage_factory",
+}
+"""Storage factories for files provided by this package."""
 
 RECORDS_RESOURCES_DEFAULT_TRANSFER_TYPE = "L"
-"""Default transfer class to use. 
+"""Default transfer class to use.
 One of 'L' (local), 'F' (fetch), 'R' (point to remote), 'M' (multipart)."""

--- a/invenio_records_resources/ext.py
+++ b/invenio_records_resources/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2022 CERN.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -51,3 +51,13 @@ class InvenioRecordsResources(object):
         for k in dir(config):
             if k.startswith("RECORDS_RESOURCES_") or k.startswith("SITE_"):
                 app.config.setdefault(k, getattr(config, k))
+
+        rest_storage_factories = app.config.setdefault(
+            "FILES_REST_STORAGE_FACTORIES", {}
+        )
+        for (
+            storage_class,
+            storage_factory,
+        ) in config.FILES_REST_STORAGE_FACTORIES.items():
+            if storage_class not in rest_storage_factories:
+                rest_storage_factories[storage_class] = storage_factory

--- a/invenio_records_resources/records/storage.py
+++ b/invenio_records_resources/records/storage.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CESNET.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+"""
+Implementation of additional storage backends.
+"""
+
+import requests
+from invenio_files_rest.storage import FileStorage
+
+
+class RemoteFileStorage(FileStorage):
+    """Remote storage backend. This backend is used for storing files
+    in a remote location (such as a different web server) and invenio
+    does not manage the storage directly (and has no control over it).
+    """
+
+    def __init__(self, fileurl, size=None, modified=None):
+        """Storage initialization."""
+        self.fileurl = fileurl
+        super().__init__(size=size, modified=modified)
+
+    def open(self, mode="rb"):
+        """Open file.
+
+        The caller is responsible for closing the file.
+        """
+        if mode != "rb":
+            raise NotImplementedError("Only read binary mode is supported.")
+        return requests.get(self.fileurl, stream=True).raw
+
+    def delete(self):
+        """Delete a file.
+
+        This is a no-op for remote storage as we do not own the storage."""
+        return False
+
+    def initialize(self, size=0):
+        """Initialize file on storage and truncate to given size."""
+        raise NotImplementedError("Remote storage does not support initialization.")
+
+    def save(
+        self,
+        incoming_stream,
+        size_limit=None,
+        size=None,
+        chunk_size=None,
+        progress_callback=None,
+    ):
+        """Save file in the file system."""
+        raise NotImplementedError("Remote storage does not support saving.")
+
+    def update(
+        self,
+        incoming_stream,
+        seek=0,
+        size=None,
+        chunk_size=None,
+        progress_callback=None,
+    ):
+        """Update a file in the file system."""
+        raise NotImplementedError("Remote storage does not support updating.")
+
+
+def remote_storage_factory(
+    fileinstance=None,
+    default_location=None,
+    default_storage_class=None,
+    filestorage_class=RemoteFileStorage,
+    fileurl=None,
+    size=None,
+    modified=None,
+    clean_dir=True,
+):
+    """Get factory function for creating a PyFS file storage instance."""
+    # Either the FileInstance needs to be specified or all filestorage
+    # class parameters need to be specified
+    assert fileinstance or (fileurl and size)
+
+    if fileinstance:
+        fileurl = fileinstance.uri
+
+    return filestorage_class(fileurl, size=size, modified=modified)

--- a/invenio_records_resources/services/files/transfer/constants.py
+++ b/invenio_records_resources/services/files/transfer/constants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021-2024 CERN.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -13,3 +13,6 @@ LOCAL_TRANSFER_TYPE = "L"
 FETCH_TRANSFER_TYPE = "F"
 REMOTE_TRANSFER_TYPE = "R"
 MULTIPART_TRANSFER_TYPE = "M"
+
+# remote storage class
+REMOTE_STORAGE_CLASS = "R"

--- a/invenio_records_resources/services/files/transfer/providers/remote.py
+++ b/invenio_records_resources/services/files/transfer/providers/remote.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021-2024 CERN.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -16,7 +16,7 @@ from marshmallow import ValidationError, fields, validate, validates
 
 from ...schema import BaseTransferSchema
 from ..base import Transfer, TransferStatus
-from ..constants import REMOTE_TRANSFER_TYPE
+from ..constants import REMOTE_STORAGE_CLASS, REMOTE_TRANSFER_TYPE
 
 
 class RemoteTransferBase(Transfer):
@@ -27,9 +27,9 @@ class RemoteTransferBase(Transfer):
 
         url = fields.Str(required=True, load_only=True)
         """URL that points to the remote file.
-        
+
         It is not dumped to the client as it would make download statistics impossible.
-        The file is accessed by using the /content url and then a 302 redirect 
+        The file is accessed by using the /content url and then a 302 redirect
         is sent to the client with the actual URI.
         """
 
@@ -81,5 +81,6 @@ class RemoteTransfer(RemoteTransferBase):
                 checksum=file_metadata.get("checksum"),
                 readable=False,
             )
+            fi.storage_class = REMOTE_STORAGE_CLASS
         obj = ObjectVersion.create(record.files.bucket, file_metadata["key"], fi.id)
         return super().init_file(record, file_metadata, obj=obj)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2020-2023 CERN.
 # Copyright (C) 2020 Northwestern University.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 # Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
@@ -15,7 +15,10 @@ See https://pytest-invenio.readthedocs.io/ for documentation on which test
 fixtures are available.
 """
 
+from io import BytesIO
+
 import pytest
+import requests
 from flask_principal import Identity, Need, UserNeed
 from invenio_app.factory import create_api as _create_api
 
@@ -113,3 +116,18 @@ def identity_simple():
     i.provides.add(Need(method="system_role", value="any_user"))
     i.provides.add(Need(method="system_role", value="authenticated_user"))
     return i
+
+
+@pytest.fixture()
+def monkey_remote_file(monkeypatch):
+
+    class MockResponse:
+        def __init__(self):
+            self.status_code = 200
+            self.raw = BytesIO(b"There is a monkey here!")
+
+    def mock_get(*args, **kwargs):
+        return MockResponse()
+
+    # apply the monkeypatch for requests.get to mock_get
+    monkeypatch.setattr(requests, "get", mock_get)

--- a/tests/mock_module/permissions.py
+++ b/tests/mock_module/permissions.py
@@ -3,7 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -55,7 +55,8 @@ class PermissionPolicy(RecordPermissionPolicy):
     can_commit_files = [
         IfTransferType(LOCAL_TRANSFER_TYPE, AnyUser()),
         IfTransferType(FETCH_TRANSFER_TYPE, SystemProcess()),
-        IfTransferType(MULTIPART_TRANSFER_TYPE, AnyUser()),
+        IfTransferType(MULTIPART_TRANSFER_TYPE, AuthenticatedUser()),
+        IfTransferType(REMOTE_TRANSFER_TYPE, AuthenticatedUser()),
         SystemProcess(),
     ]
     can_read_files = [AnyUser(), SystemProcess()]

--- a/tests/resources/test_files_resource.py
+++ b/tests/resources/test_files_resource.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020-2024 CERN.
 # Copyright (C) 2021 Northwestern University.
 # Copyright (C) 2021 European Union.
-# Copyright (C) 2025 CESNET.
+# Copyright (C) 2025-2026 CESNET.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -16,6 +16,9 @@ from io import BytesIO
 from unittest.mock import patch
 
 import pytest
+from flask_security import login_user
+from flask_security.utils import hash_password
+from invenio_accounts.testutils import login_user_via_session
 from zipstream import ZipStream
 
 from tests.mock_module import service_for_files, service_for_records_w_files
@@ -57,6 +60,35 @@ def base_app(
 def input_data(input_data):
     input_data["files"] = {"enabled": True}
     return input_data
+
+
+@pytest.fixture()
+def users(app, db):
+    """Create example user."""
+    with db.session.begin_nested():
+        datastore = app.extensions["security"].datastore
+        user1 = datastore.create_user(
+            email="info@inveniosoftware.org",
+            password=hash_password("password"),
+            active=True,
+        )
+        user2 = datastore.create_user(
+            email="ser-testalot@inveniosoftware.org",
+            password=hash_password("beetlesmasher"),
+            active=True,
+        )
+
+    db.session.commit()
+    return [user1, user2]
+
+
+@pytest.fixture()
+def client_with_login(client, users):
+    """Log in a user to the client."""
+    user = users[0]
+    login_user(user)
+    login_user_via_session(client, email=user.email)
+    return client
 
 
 def test_files_api_flow(client, search_clear, headers, input_data, location):
@@ -422,8 +454,7 @@ def test_disable_files_when_files_already_present_should_error(
         {
             "field": "files.enabled",
             "messages": [
-                "You must first delete all files to set the record to be "
-                "metadata-only."
+                "You must first delete all files to set the record to be metadata-only."
             ],
         }
     ]
@@ -710,3 +741,41 @@ def test_malformed_range(
     )
     # should probably be 400 but werkzeug reports this as 416
     assert res.status_code == 416
+
+
+def test_remote_files_flow(
+    client_with_login, search_clear, headers, input_data, location, monkey_remote_file
+):
+    """Test record creation."""
+
+    # Initialize a draft
+    res = client_with_login.post("/mocks", headers=headers, json=input_data)
+    assert res.status_code == 201
+    id_ = res.json["id"]
+    assert res.json["links"]["files"].endswith(f"/api/mocks/{id_}/files")
+
+    # Initialize files upload
+    res = client_with_login.post(
+        f"/mocks/{id_}/files",
+        headers=headers,
+        json=[
+            {
+                "key": "article.txt",
+                "transfer": {
+                    "url": "https://inveniordm.test/files/article.txt",
+                    "type": "R",
+                },
+            },
+        ],
+    )
+    assert res.status_code == 201
+    print(res.json)
+
+    # Commit the uploaded file
+    res = client_with_login.get(f"/mocks/{id_}/files-archive", headers=headers)
+    assert res.status_code == 200
+    # res.content is a zip file, test it
+    zip_data = res.data
+    with zipfile.ZipFile(BytesIO(zip_data)) as zip_file:
+        assert set(zip_file.namelist()) == {"article.txt"}
+        assert zip_file.open("article.txt").read() == b"There is a monkey here!"

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -16,6 +16,7 @@ import pytest
 from flask_principal import Identity
 from invenio_access import any_user
 from invenio_access.permissions import system_identity
+from invenio_db import db
 from invenio_files_rest.errors import FileSizeError
 from marshmallow import ValidationError
 
@@ -666,10 +667,7 @@ def test_multipart_file_upload_local_storage(
 
 
 def test_remote_file(
-    file_service,
-    example_file_record,
-    identity_simple,
-    location,
+    file_service, example_file_record, identity_simple, location, monkey_remote_file
 ):
     """Test the lifecycle of an external remote file."""
 
@@ -692,6 +690,14 @@ def test_remote_file(
     assert file_result["transfer"]["type"] == "R"
     assert "url" not in file_result["transfer"]
     assert file_result["status"] == "completed"
+
+    file_rec = example_file_record.files["article.txt"]
+    object_version = file_rec.object_version
+    file_instance = object_version.file
+    assert file_instance.storage_class == "R"
+
+    # compute the checksum of the file
+    assert file_instance.storage().checksum() == "md5:0278379568c79fd509640d1b9eb082b7"
 
     sent_file = file_service.get_file_content(
         identity_simple, recid, "article.txt"


### PR DESCRIPTION
### Description

This PR introduces a storage provider for remote files and fixes related issues in the file handling workflow.

The implementation adds a storage factory capable of opening/accessing remote files on the record level. This makes remote files behave exactly the same as local files and fixes issues related to checksum calculation and archive generation when remote files are present - https://github.com/inveniosoftware/invenio-records-resources/issues/672.

> [!NOTE]
> This PR depends on https://github.com/inveniosoftware/invenio-files-rest/pull/348

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
