### PR TITLE
ui(translations): mark string as translatable

### DIFF
--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -48,7 +48,7 @@ from ..services.errors import (
 class HTTPJSONValidationException(HTTPJSONException):
     """HTTP exception serializing to JSON and reflecting Marshmallow errors."""
 
-    description = "A validation error occurred."
+    description = _("A validation error occurred.")
 
     def __init__(self, exception):
         """Constructor."""


### PR DESCRIPTION
### Description

Marked validation message as translatable that wasn't previously.


### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).