### PR TITLE
feat(facets): configurable `post_filter` and dynamic bounds for `DateFacet`

### DIFF
--- a/invenio_records_resources/services/records/facets/__init__.py
+++ b/invenio_records_resources/services/records/facets/__init__.py
@@ -13,6 +13,7 @@ from .facets import (
     CFTermsFacet,
     CombinedTermsFacet,
     DateFacet,
+    Facet,
     NestedTermsFacet,
     TermsFacet,
 )
@@ -21,6 +22,7 @@ from .response import FacetsResponse
 
 __all__ = (
     "CFTermsFacet",
+    "Facet",
     "FacetsResponse",
     "NestedTermsFacet",
     "RecordRelationLabels",

--- a/invenio_records_resources/services/records/facets/facets.py
+++ b/invenio_records_resources/services/records/facets/facets.py
@@ -16,6 +16,30 @@ from dateutil.parser import isoparse
 from invenio_search.engine import dsl
 
 
+class Facet(dsl.Facet):
+    """Base facet with filtering behavior defaults.
+
+    Subclasses can override ``post_filter`` to control whether their filter is
+    applied as a post_filter (preserves aggregation counts from the full result
+    set) or as a direct query filter (aggregations reflect filtered results).
+
+    ``post_filter`` can be set as a class attribute, passed to the constructor,
+    or set on an instance after construction.
+    """
+
+    post_filter = True
+
+    def __init__(self, post_filter=None, **kwargs):
+        """Constructor."""
+        if post_filter is not None:
+            self.post_filter = post_filter
+        super().__init__(**kwargs)
+
+    def prepare_aggregation(self, filter_values):
+        """Prepare the aggregation based on active filter values. No-op by default."""
+        pass
+
+
 class LabelledFacetMixin:
     """Mixin class for overwriting the default get_values() method."""
 
@@ -73,7 +97,7 @@ class LabelledFacetMixin:
         return {"buckets": out, "label": str(self._label)}
 
 
-class TermsFacet(LabelledFacetMixin, dsl.TermsFacet):
+class TermsFacet(LabelledFacetMixin, Facet, dsl.TermsFacet):
     """Terms facet.
 
     .. code-block:: python
@@ -481,7 +505,7 @@ class CFNestedTermsFacet(CFFacetMixin, NestedTermsFacet):
         super().__init__(label, value_labels, **kwargs)
 
 
-class DateFacet(LabelledFacetMixin, dsl.Facet):
+class DateFacet(LabelledFacetMixin, Facet):
     """Date-based facet using date_histogram aggregation.
 
     Supports:

--- a/invenio_records_resources/services/records/facets/facets.py
+++ b/invenio_records_resources/services/records/facets/facets.py
@@ -516,8 +516,8 @@ class DateFacet(LabelledFacetMixin, Facet):
     - Explicit bounds: (2014..2020], [2014..2020)
 
     The facet values are normalized to full date ranges before being sent to
-    OpenSearch. Inclusive and exclusive bounds are controlled with brackets: "["/"]" include and
-    "("/")" exclude the boundary.
+    OpenSearch. Inclusive and exclusive bounds are controlled with brackets:
+    "["/"]" include and "("/")" exclude the boundary.
 
     OpenSearch range operators:
     - gte: greater than or equal (inclusive lower bound)
@@ -537,6 +537,10 @@ class DateFacet(LabelledFacetMixin, Facet):
             }
         }
     }
+
+    Supports optional ``hard_bounds`` to limit the histogram range, with
+    automatic bounds adjustment when the active filter extends outside the
+    configured bounds (see ``_effective_bounds``).
     """
 
     def __init__(
@@ -546,6 +550,7 @@ class DateFacet(LabelledFacetMixin, Facet):
         interval="year",
         format="yyyy",
         separator="..",
+        hard_bounds=None,
         **kwargs,
     ):
         """Constructor."""
@@ -554,6 +559,8 @@ class DateFacet(LabelledFacetMixin, Facet):
         self._interval = interval
         self._format = format
         self._separator = separator
+        self._active_filter_values = None
+        self._hard_bounds = hard_bounds
         self._range_re = re.compile(
             rf"""
             (?P<open>[\(\[])?          # optional opening bracket
@@ -566,15 +573,100 @@ class DateFacet(LabelledFacetMixin, Facet):
         )
         super().__init__(label=label, **kwargs)
 
+    def prepare_aggregation(self, filter_values):
+        """Prepare the aggregation by storing active filter values.
+
+        Called before ``get_aggregation`` so that ``_effective_bounds`` can
+        adjust ``hard_bounds`` when the filter range extends outside the
+        configured bounds.
+        """
+        self._active_filter_values = filter_values
+
     def get_aggregation(self):
-        """Get the aggregation."""
-        return dsl.A(
-            "date_histogram",
-            field=self._field,
-            calendar_interval=self._interval,
-            format=self._format,
-            min_doc_count=0,
-        )
+        """Get the date_histogram aggregation."""
+        agg_params = {
+            "field": self._field,
+            "calendar_interval": self._interval,
+            "format": self._format,
+            "min_doc_count": 0,
+        }
+        bounds = self._effective_bounds()
+        if bounds:
+            agg_params["hard_bounds"] = bounds
+        return dsl.A("date_histogram", **agg_params)
+
+    def _effective_bounds(self):
+        """Compute effective hard_bounds for the aggregation.
+
+        When a filter range extends outside the configured ``hard_bounds``,
+        the bounds are replaced with the filter range. This keeps the
+        histogram focused on the range the user is looking at.
+
+        Examples (with default hard_bounds ``{"min": "1800", "max": "now/y"}``):
+
+        - Filter ``1500..1700`` → bounds become ``{"min": "1500-01-01",
+          "max": "1700-12-31"}`` (filter is entirely below min).
+        - Filter ``1500..2020`` → bounds become ``{"min": "1500-01-01",
+          "max": "2020-12-31"}`` (filter starts below min).
+        - Filter ``2020..2025`` → bounds stay ``{"min": "1800",
+          "max": "now/y"}`` (filter is within bounds).
+        - Filter ``2020..3000`` → bounds stay as-is because ``"now/y"``
+          is treated as unbounded (never exceeded).
+
+        Date values are compared as normalized ``YYYY-MM-DD`` strings, which
+        sort correctly regardless of the calendar interval.
+        """
+        if not self._hard_bounds or not self._active_filter_values:
+            return self._hard_bounds
+
+        for value in self._active_filter_values:
+            r = self._normalize_value(value)
+            if r is None:
+                continue
+
+            bounds_min = self._resolve_bound(self._hard_bounds.get("min"), True)
+            bounds_max = self._resolve_bound(self._hard_bounds.get("max"), False)
+
+            outside = (r["start"] and bounds_min and r["start"] < bounds_min) or (
+                r["end"] and bounds_max and r["end"] > bounds_max
+            )
+
+            if outside:
+                new_bounds = {}
+                if r["start"]:
+                    new_bounds["min"] = self._format_bound(r["start"])
+                if r["end"]:
+                    new_bounds["max"] = self._format_bound(r["end"])
+                return new_bounds
+
+        return self._hard_bounds
+
+    _FORMAT_SLICE = {
+        "yyyy": 4,
+        "yyyy-MM": 7,
+        "yyyy-MM-dd": 10,
+    }
+
+    def _format_bound(self, normalized_date):
+        """Format a normalized YYYY-MM-DD date to match the aggregation format."""
+        length = self._FORMAT_SLICE.get(self._format, 4)
+        return normalized_date[:length]
+
+    def _resolve_bound(self, value, is_start):
+        """Resolve a bounds value to a comparable YYYY-MM-DD string.
+
+        Returns None for dynamic expressions like ``"now/y"`` (never exceeded
+        by a filter) and for unsupported types.
+        """
+        if not value:
+            return None
+        if isinstance(value, int):
+            value = str(value)
+        if not isinstance(value, str):
+            return None
+        if value.startswith("now"):
+            return None
+        return self._normalize_date(value, is_start)
 
     def add_filter(self, filter_values):
         """Construct a filter query for the facet."""
@@ -591,7 +683,7 @@ class DateFacet(LabelledFacetMixin, Facet):
         return q
 
     def _build_range_query(self, value):
-        """Build an Opensearch range query from a value."""
+        """Build an OpenSearch range query from a value."""
         r = self._normalize_value(value)
         if r is None:
             return None

--- a/invenio_records_resources/services/records/params/facets.py
+++ b/invenio_records_resources/services/records/params/facets.py
@@ -31,31 +31,45 @@ class FacetsParam(ParamInterpreter):
 
     def add_filter(self, name, values):
         """Add a filter for a facet."""
-        # Store selected facet values for later usage
         self.selected_values[name] = values
-        # Create a filter for a single facet
         f = self.facets[name].add_filter(values)
-        if f is None:
-            return
-        # Store filter.
-        self._filters[name] = f
+        if f is not None:
+            self._filters[name] = f
+
+    @staticmethod
+    def _combine(filters):
+        """Combine filters with AND."""
+        combined = filters[0]
+        for f in filters[1:]:
+            combined &= f
+        return combined
 
     def filter(self, search):
-        """Apply a post filter on the search."""
+        """Apply filters on the search."""
         if not self._filters:
             return search
 
-        filters = list(self._filters.values())
+        facets = self.facets
+        post_filters, direct_filters = [], []
+        for name, f in self._filters.items():
+            if getattr(facets[name], "post_filter", True):
+                post_filters.append(f)
+            else:
+                direct_filters.append(f)
 
-        post_filter = filters[0]
-        for f in filters[1:]:
-            post_filter &= f
+        if direct_filters:
+            search = search.filter(self._combine(direct_filters))
+        if post_filters:
+            search = search.post_filter(self._combine(post_filters))
 
-        return search.post_filter(post_filter)
+        return search
 
     def aggregate(self, search):
         """Add aggregations representing the facets."""
-        for name, facet in self.facets.items():
+        facets = self.facets
+        for name, facet in facets.items():
+            if name in self.selected_values and hasattr(facet, "prepare_aggregation"):
+                facet.prepare_aggregation(list(self.selected_values[name]))
             agg = facet.get_aggregation()
             search.aggs.bucket(name, agg)
         return search

--- a/invenio_records_resources/services/records/params/facets.py
+++ b/invenio_records_resources/services/records/params/facets.py
@@ -38,7 +38,9 @@ class FacetsParam(ParamInterpreter):
 
     @staticmethod
     def _combine(filters):
-        """Combine filters with AND."""
+        """Combine filters with AND. Returns None if no filters."""
+        if not filters:
+            return None
         combined = filters[0]
         for f in filters[1:]:
             combined &= f
@@ -57,10 +59,12 @@ class FacetsParam(ParamInterpreter):
             else:
                 direct_filters.append(f)
 
-        if direct_filters:
-            search = search.filter(self._combine(direct_filters))
-        if post_filters:
-            search = search.post_filter(self._combine(post_filters))
+        direct = self._combine(direct_filters)
+        if direct is not None:
+            search = search.filter(direct)
+        post = self._combine(post_filters)
+        if post is not None:
+            search = search.post_filter(post)
 
         return search
 

--- a/tests/services/test_service_date_facet.py
+++ b/tests/services/test_service_date_facet.py
@@ -29,16 +29,68 @@ class DateSearchOptions(SearchOptions):
     }
 
 
+class DateBoundedSearchOptions(SearchOptions):
+    """Search options with hard_bounds."""
+
+    facets = {
+        "publication_date": DateFacet(
+            field="metadata.publication_date_range",
+            label="Publication year",
+            interval="year",
+            separator="..",
+            hard_bounds={"min": "2019", "max": "now/y"},
+        )
+    }
+
+
+class DateDirectFilterSearchOptions(SearchOptions):
+    """Search options with post_filter=False."""
+
+    facets = {
+        "publication_date": DateFacet(
+            field="metadata.publication_date_range",
+            label="Publication year",
+            interval="year",
+            separator="..",
+            post_filter=False,
+        )
+    }
+
+
 class DateServiceConfig(ServiceConfig):
     """Service config for date facet tests."""
 
     search = DateSearchOptions
 
 
+class DateBoundedServiceConfig(ServiceConfig):
+    """Service config with hard_bounds."""
+
+    search = DateBoundedSearchOptions
+
+
+class DateDirectFilterServiceConfig(ServiceConfig):
+    """Service config with post_filter=False."""
+
+    search = DateDirectFilterSearchOptions
+
+
 @pytest.fixture()
 def date_service(appctx):
     """Service instance for date facet tests."""
     return RecordService(DateServiceConfig)
+
+
+@pytest.fixture()
+def date_bounded_service(appctx):
+    """Service instance with hard_bounds."""
+    return RecordService(DateBoundedServiceConfig)
+
+
+@pytest.fixture()
+def date_direct_filter_service(appctx):
+    """Service instance with post_filter=False."""
+    return RecordService(DateDirectFilterServiceConfig)
 
 
 @pytest.fixture()
@@ -199,6 +251,88 @@ def test_date_facets_invalid_filter(app, date_service, identity_simple, date_rec
     assert 3 == len(res)
 
 
+@pytest.fixture()
+def date_records_wide(app, date_service, identity_simple, search_clear):
+    """Records spanning a wide date range for bounds testing."""
+    items = []
+    for year, title in [(1700, "old"), (2019, "recent-1"), (2020, "recent-2")]:
+        items.append(
+            date_service.create(
+                identity_simple,
+                {
+                    "metadata": {
+                        "title": title,
+                        "publication_date_range": {
+                            "gte": f"{year}-01-01",
+                            "lte": f"{year}-12-31",
+                        },
+                    }
+                },
+            )
+        )
+    Record.index.refresh()
+    return items
+
+
+def test_hard_bounds_clips_histogram(
+    app, date_bounded_service, identity_simple, date_records_wide
+):
+    """hard_bounds clips histogram buckets to the configured range."""
+    res = date_bounded_service.search(identity_simple)
+    bucket_keys = [b["key"] for b in res.aggregations["publication_date"]["buckets"]]
+    # 1700 should be clipped by hard_bounds min=2019
+    assert "1700" not in bucket_keys
+    assert "2019" in bucket_keys
+    assert "2020" in bucket_keys
+    # All 3 records still returned (hard_bounds only affects aggregation)
+    assert 3 == len(res)
+
+
+def test_hard_bounds_expand_outside_filter(
+    app, date_bounded_service, identity_simple, date_records_wide
+):
+    """Filtering outside hard_bounds expands bounds to show filter range."""
+    res = date_bounded_service.search(
+        identity_simple, facets={"publication_date": ["1600..1800"]}
+    )
+    bucket_keys = [b["key"] for b in res.aggregations["publication_date"]["buckets"]]
+    # Bounds expanded to filter range, 1700 bucket should appear
+    assert "1700" in bucket_keys
+    # Only the 1700 record matches the filter
+    assert 1 == len(res)
+
+
+def test_post_filter_false_affects_aggregations(
+    app, date_direct_filter_service, identity_simple, date_records_wide
+):
+    """post_filter=False makes aggregations reflect filtered results."""
+    res = date_direct_filter_service.search(
+        identity_simple, facets={"publication_date": ["2020"]}
+    )
+    buckets = res.aggregations["publication_date"]["buckets"]
+    non_zero = [b for b in buckets if b["doc_count"] > 0]
+    # Only 2020 bucket should have counts (direct filter affects aggregation)
+    assert all(b["key"] == "2020" for b in non_zero)
+    assert 1 == len(res)
+
+
+def test_post_filter_true_preserves_aggregations(
+    app, date_service, identity_simple, date_records_wide
+):
+    """Default post_filter=True preserves aggregation counts from full result set."""
+    res = date_service.search(identity_simple, facets={"publication_date": ["2020"]})
+    buckets = {
+        b["key"]: b["doc_count"]
+        for b in res.aggregations["publication_date"]["buckets"]
+    }
+    # 1700 and 2019 buckets still have counts (post_filter doesn't affect aggs)
+    assert buckets.get("1700", 0) == 1
+    assert buckets.get("2019", 0) == 1
+    assert buckets.get("2020", 0) == 1
+    # But only 2020 records returned
+    assert 1 == len(res)
+
+
 def test_date_facet_normalize_value():
     facet = DateFacet(
         field="metadata.publication_date_range",
@@ -251,3 +385,88 @@ def test_date_facet_last_day_of_month():
     assert 29 == DateFacet._last_day_of_month(2020, 2)
     assert 28 == DateFacet._last_day_of_month(2019, 2)
     assert 31 == DateFacet._last_day_of_month(2021, 12)
+
+
+def test_date_facet_post_filter():
+    """post_filter defaults to True and can be overridden per-instance."""
+    facet = DateFacet(field="date", label="Date")
+    assert facet.post_filter is True
+
+    facet_direct = DateFacet(field="date", label="Date", post_filter=False)
+    assert facet_direct.post_filter is False
+
+    # Other instances are unaffected
+    assert facet.post_filter is True
+
+
+def test_date_facet_hard_bounds_aggregation():
+    """hard_bounds is passed to the aggregation when configured."""
+    facet = DateFacet(
+        field="date",
+        label="Date",
+        hard_bounds={"min": "1800", "max": "now/y"},
+    )
+    agg = facet.get_aggregation()
+    assert agg.to_dict()["date_histogram"]["hard_bounds"] == {
+        "min": "1800",
+        "max": "now/y",
+    }
+
+    # Without hard_bounds, no hard_bounds key
+    facet_no_bounds = DateFacet(field="date", label="Date")
+    agg = facet_no_bounds.get_aggregation()
+    assert "hard_bounds" not in agg.to_dict()["date_histogram"]
+
+
+def test_date_facet_effective_bounds():
+    """Effective bounds adjust when filter extends outside configured bounds."""
+    bounds = {"min": "1800", "max": "now/y"}
+
+    def make_facet(filter_value):
+        f = DateFacet(field="date", label="Date", hard_bounds=bounds.copy())
+        f.prepare_aggregation([filter_value])
+        return f._effective_bounds()
+
+    # Within bounds — unchanged
+    assert make_facet("2020..2025") == {"min": "1800", "max": "now/y"}
+
+    # Entirely below min — replaced with filter range
+    assert make_facet("1500..1700") == {"min": "1500", "max": "1700"}
+
+    # Crossing min — replaced with filter range
+    assert make_facet("1500..2020") == {"min": "1500", "max": "2020"}
+
+    # Above max but "now/y" is never exceeded
+    assert make_facet("2020..3000") == {"min": "1800", "max": "now/y"}
+
+    # Open-ended range below min
+    assert make_facet("1500..") == {"min": "1500"}
+
+    # No mutation of original _hard_bounds
+    facet = DateFacet(field="date", label="Date", hard_bounds=bounds.copy())
+    facet.prepare_aggregation(["1500..1700"])
+    facet._effective_bounds()
+    assert facet._hard_bounds == {"min": "1800", "max": "now/y"}
+
+
+def test_date_facet_format_bound():
+    """Bounds are formatted to match the aggregation format."""
+    facet_y = DateFacet(field="date", label="Date", format="yyyy")
+    assert facet_y._format_bound("1500-01-01") == "1500"
+    assert facet_y._format_bound("2020-06-15") == "2020"
+
+    facet_ym = DateFacet(field="date", label="Date", format="yyyy-MM")
+    assert facet_ym._format_bound("2020-06-15") == "2020-06"
+
+    facet_ymd = DateFacet(field="date", label="Date", format="yyyy-MM-dd")
+    assert facet_ymd._format_bound("2020-06-15") == "2020-06-15"
+
+    # Effective bounds respect format
+    facet = DateFacet(
+        field="date",
+        label="Date",
+        format="yyyy",
+        hard_bounds={"min": "1800", "max": "now/y"},
+    )
+    facet.prepare_aggregation(["1000..1800"])
+    assert facet._effective_bounds() == {"min": "1000", "max": "1800"}


### PR DESCRIPTION
> AI use disclosure: I developed majority of the feature with Claude Code Opus 4.6. Most of corrections/guidance were related to naming, backwards compat, concerns on thread safety (since we're "storing" the selected facet values on the facet object, which turned out to be fine since we're deepcopy-ing things on every request). 

WIP: I would like to put a before/after video in the companion PR at https://github.com/inveniosoftware/react-searchkit/pull/297 to showcase the new behavior.

- **feat(facets): add Facet base class with post_filter and prepare_aggregation**
  * Add Facet base class (subclassing dsl.Facet) with:
    - ``post_filter`` attribute controlling filter application strategy
    - ``prepare_aggregation()`` hook called before ``get_aggregation()``
  * Update TermsFacet and DateFacet to inherit from Facet
  * Split FacetsParam.filter() into post_filters and direct_filters
  * Add FacetsParam._combine() helper
  * Call prepare_aggregation() during aggregation phase
  

- **feat(facets): add hard_bounds and dynamic bounds to DateFacet**
  * Add optional ``hard_bounds`` param to DateFacet for date_histogram
    aggregations (e.g. ``hard_bounds={"min": "1800", "max": "now/y"}``)
  * Implement ``prepare_aggregation()`` to store active filter values
  * Add ``_effective_bounds()`` to dynamically replace hard_bounds with
    the filter range when it extends outside configured bounds
  * Bounds computation is side-effect free (no mutation of _hard_bounds)
  