### PR TITLE
feat(facets): add `bounds_mode` to DateFacet and fix year padding

### DIFF
--- a/invenio_records_resources/services/records/facets/facets.py
+++ b/invenio_records_resources/services/records/facets/facets.py
@@ -10,7 +10,7 @@
 """Facets types defined."""
 
 import re
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.parser import isoparse
 from invenio_search.engine import dsl
@@ -643,23 +643,69 @@ class DateFacet(LabelledFacetMixin, Facet):
         """Check if a normalized filter range extends outside hard_bounds."""
         if not self._hard_bounds:
             return False
+
         bounds_min = self._resolve_bound(self._hard_bounds.get("min"), True)
         bounds_max = self._resolve_bound(self._hard_bounds.get("max"), False)
-        start, end = normalized_filter["start"], normalized_filter["end"]
-        return (start and bounds_min and start < bounds_min) or (
-            end and bounds_max and end > bounds_max
-        )
+        start = self._effective_date(normalized_filter, is_start=True)
+        end = self._effective_date(normalized_filter, is_start=False)
 
-    _FORMAT_SLICE = {
-        "yyyy": 4,
-        "yyyy-MM": 7,
-        "yyyy-MM-dd": 10,
-    }
+        starts_before = bool(start and bounds_min and start < bounds_min)
+        ends_after = bool(end and bounds_max and end > bounds_max)
+        return starts_before or ends_after
+
+    def _effective_date(self, normalized_filter, is_start):
+        """Compute the actual first/last matching date, mirroring date math rounding."""
+        raw = normalized_filter["start_raw" if is_start else "end_raw"]
+        normalized = normalized_filter["start" if is_start else "end"]
+        inclusive = normalized_filter[
+            "start_inclusive" if is_start else "end_inclusive"
+        ]
+        if not raw or not normalized:
+            return None
+        if inclusive:
+            return normalized
+        return self._next_period(raw, is_start)
+
+    @staticmethod
+    def _next_period(raw, is_start):
+        """Shift a raw date by one period (year/month/day) based on its precision."""
+        try:
+            dt = isoparse(raw).date()
+        except (ValueError, TypeError):
+            return None
+        length = len(raw)
+        if length == len("YYYY"):
+            # Year precision: e.g. "1970" → 1971-01-01 (start) or 1969-12-31 (end)
+            shifted = date(
+                dt.year + (1 if is_start else -1),
+                1 if is_start else 12,
+                1 if is_start else 31,
+            )
+        elif length == len("YYYY-MM"):
+            # Month precision: shift by one month, handling year wrap
+            year, month = dt.year, dt.month
+            if is_start:
+                year, month = (year + 1, 1) if month == 12 else (year, month + 1)
+                shifted = date(year, month, 1)
+            else:
+                year, month = (year - 1, 12) if month == 1 else (year, month - 1)
+                shifted = date(year, month, DateFacet._last_day_of_month(year, month))
+        elif length == len("YYYY-MM-DD"):
+            # Day precision: simply ±1 day
+            shifted = dt + (timedelta(days=1) if is_start else timedelta(days=-1))
+        else:
+            return None
+        return f"{shifted.year:04d}-{shifted.month:02d}-{shifted.day:02d}"
 
     def _format_bound(self, normalized_date):
         """Format a normalized YYYY-MM-DD date to match the aggregation format."""
-        length = self._FORMAT_SLICE.get(self._format, 4)
-        return normalized_date[:length]
+        if self._format == "yyyy":
+            return normalized_date[: len("YYYY")]
+        if self._format == "yyyy-MM":
+            return normalized_date[: len("YYYY-MM")]
+        if self._format == "yyyy-MM-dd":
+            return normalized_date[: len("YYYY-MM-DD")]
+        return normalized_date[: len("YYYY")]
 
     def _resolve_bound(self, value, is_start):
         """Resolve a bounds value to a comparable YYYY-MM-DD string.
@@ -699,11 +745,13 @@ class DateFacet(LabelledFacetMixin, Facet):
 
         es_range = {}
 
-        if r["start"]:
-            es_range["gte" if r["start_inclusive"] else "gt"] = r["start"]
+        if r["start_raw"]:
+            op = "gte" if r["start_inclusive"] else "gt"
+            es_range[op] = self._with_rounding(r["start_raw"])
 
-        if r["end"]:
-            es_range["lte" if r["end_inclusive"] else "lt"] = r["end"]
+        if r["end_raw"]:
+            op = "lte" if r["end_inclusive"] else "lt"
+            es_range[op] = self._with_rounding(r["end_raw"])
 
         return dsl.Q(
             "range",
@@ -714,6 +762,24 @@ class DateFacet(LabelledFacetMixin, Facet):
                 }
             },
         )
+
+    @staticmethod
+    def _with_rounding(raw):
+        """Append OpenSearch date math rounding based on input precision.
+
+        Without rounding, ``(1970..]`` would match dates strictly after
+        ``1970-01-01T00:00:00`` (e.g., 1970-06-15). With ``||/y`` rounding,
+        ``gt: "1970||/y"`` matches dates after the end of 1970, i.e. starting
+        from 1971-01-01 — which is what users expect.
+        """
+        length = len(raw)
+        if length == len("YYYY"):
+            return f"{raw}||/y"
+        if length == len("YYYY-MM"):
+            return f"{raw}||/M"
+        if length == len("YYYY-MM-DD"):
+            return f"{raw}||/d"
+        return raw
 
     def is_filtered(self, key, filter_values):
         """Check if a histogram bucket year is selected by any range."""
@@ -727,20 +793,12 @@ class DateFacet(LabelledFacetMixin, Facet):
             if r is None:
                 continue
 
-            if r["start"]:
-                start_year = int(r["start"][:4])
-                if year < start_year:
-                    continue
-                if year == start_year and not r["start_inclusive"]:
-                    continue
-
-            if r["end"]:
-                end_year = int(r["end"][:4])
-                if year > end_year:
-                    continue
-                if year == end_year and not r["end_inclusive"]:
-                    continue
-
+            start = self._effective_date(r, is_start=True)
+            end = self._effective_date(r, is_start=False)
+            if start and year < int(start[:4]):
+                continue
+            if end and year > int(end[:4]):
+                continue
             return True
 
         return False
@@ -749,22 +807,25 @@ class DateFacet(LabelledFacetMixin, Facet):
         """Normalize a value into a range dict."""
         value = value.strip()
 
-        def build_result(start, end, start_inc=True, end_inc=True):
+        def build_result(start_raw, end_raw, start_inc=True, end_inc=True):
+            start = (
+                self._normalize_date(start_raw, is_start=True) if start_raw else None
+            )
+            end = self._normalize_date(end_raw, is_start=False) if end_raw else None
             if start is None and end is None:
                 return None
             return {
                 "start": start,
                 "end": end,
+                "start_raw": start_raw,
+                "end_raw": end_raw,
                 "start_inclusive": start_inc,
                 "end_inclusive": end_inc,
             }
 
         # Single value (no separator)
         if self._separator not in value:
-            return build_result(
-                self._normalize_date(value, is_start=True),
-                self._normalize_date(value, is_start=False),
-            )
+            return build_result(value, value)
 
         # Range value
         match = self._range_re.fullmatch(value)
@@ -775,8 +836,8 @@ class DateFacet(LabelledFacetMixin, Facet):
         end_raw = match.group("end").strip() or None
 
         return build_result(
-            self._normalize_date(start_raw, is_start=True) if start_raw else None,
-            self._normalize_date(end_raw, is_start=False) if end_raw else None,
+            start_raw,
+            end_raw,
             start_inc=match.group("open") != "(",
             end_inc=match.group("close") != ")",
         )

--- a/invenio_records_resources/services/records/facets/facets.py
+++ b/invenio_records_resources/services/records/facets/facets.py
@@ -784,7 +784,7 @@ class DateFacet(LabelledFacetMixin, Facet):
         # YYYY
         if re.fullmatch(r"\d{4}", value):
             year = dt.year
-            return f"{year}-01-01" if is_start else f"{year}-12-31"
+            return f"{year:04d}-01-01" if is_start else f"{year:04d}-12-31"
 
         # YYYY-MM
         if re.fullmatch(r"\d{4}-\d{2}", value):

--- a/invenio_records_resources/services/records/facets/facets.py
+++ b/invenio_records_resources/services/records/facets/facets.py
@@ -538,9 +538,9 @@ class DateFacet(LabelledFacetMixin, Facet):
         }
     }
 
-    Supports optional ``hard_bounds`` to limit the histogram range, with
-    automatic bounds adjustment when the active filter extends outside the
-    configured bounds (see ``_effective_bounds``).
+    Supports optional ``hard_bounds`` to limit the histogram range, and
+    ``match_filter_bounds`` to control how those bounds interact with the
+    active filter (see ``_effective_bounds``).
     """
 
     def __init__(
@@ -551,6 +551,7 @@ class DateFacet(LabelledFacetMixin, Facet):
         format="yyyy",
         separator="..",
         hard_bounds=None,
+        match_filter_bounds=False,
         **kwargs,
     ):
         """Constructor."""
@@ -559,8 +560,9 @@ class DateFacet(LabelledFacetMixin, Facet):
         self._interval = interval
         self._format = format
         self._separator = separator
-        self._active_filter_values = None
         self._hard_bounds = hard_bounds
+        self._match_filter_bounds = match_filter_bounds
+        self._active_filter_values = None
         self._range_re = re.compile(
             rf"""
             (?P<open>[\(\[])?          # optional opening bracket
@@ -598,25 +600,28 @@ class DateFacet(LabelledFacetMixin, Facet):
     def _effective_bounds(self):
         """Compute effective hard_bounds for the aggregation.
 
-        When a filter range extends outside the configured ``hard_bounds``,
-        the bounds are replaced with the filter range. This keeps the
-        histogram focused on the range the user is looking at.
+        When ``match_filter_bounds`` is False (default), the configured
+        ``hard_bounds`` is used while the filter is within them, and replaced
+        with the filter range when the filter extends outside. This keeps the
+        histogram showing context around the filter selection.
 
-        Examples (with default hard_bounds ``{"min": "1800", "max": "now/y"}``):
+        When ``match_filter_bounds`` is True, the bounds always match the
+        filter range when a filter is active. The histogram focuses strictly
+        on the user's selection.
 
-        - Filter ``1500..1700`` → bounds become ``{"min": "1500-01-01",
-          "max": "1700-12-31"}`` (filter is entirely below min).
-        - Filter ``1500..2020`` → bounds become ``{"min": "1500-01-01",
-          "max": "2020-12-31"}`` (filter starts below min).
-        - Filter ``2020..2025`` → bounds stay ``{"min": "1800",
-          "max": "now/y"}`` (filter is within bounds).
-        - Filter ``2020..3000`` → bounds stay as-is because ``"now/y"``
-          is treated as unbounded (never exceeded).
+        Examples (with configured ``{"min": "1970", "max": "now/y"}``):
 
-        Date values are compared as normalized ``YYYY-MM-DD`` strings, which
-        sort correctly regardless of the calendar interval.
+        +----------------+----------------------------+-----------------+
+        | Filter         | match_filter_bounds=False  | =True           |
+        +================+============================+=================+
+        | none           | ``1970..now/y``            | ``1970..now/y`` |
+        +----------------+----------------------------+-----------------+
+        | ``2000..2026`` | ``1970..now/y``            | ``2000..2026``  |
+        +----------------+----------------------------+-----------------+
+        | ``1500..1700`` | ``1500..1700``             | ``1500..1700``  |
+        +----------------+----------------------------+-----------------+
         """
-        if not self._hard_bounds or not self._active_filter_values:
+        if not self._active_filter_values:
             return self._hard_bounds
 
         for value in self._active_filter_values:
@@ -624,22 +629,26 @@ class DateFacet(LabelledFacetMixin, Facet):
             if r is None:
                 continue
 
-            bounds_min = self._resolve_bound(self._hard_bounds.get("min"), True)
-            bounds_max = self._resolve_bound(self._hard_bounds.get("max"), False)
-
-            outside = (r["start"] and bounds_min and r["start"] < bounds_min) or (
-                r["end"] and bounds_max and r["end"] > bounds_max
-            )
-
-            if outside:
+            if self._match_filter_bounds or self._is_outside_bounds(r):
                 new_bounds = {}
                 if r["start"]:
                     new_bounds["min"] = self._format_bound(r["start"])
                 if r["end"]:
                     new_bounds["max"] = self._format_bound(r["end"])
-                return new_bounds
+                return new_bounds or self._hard_bounds
 
         return self._hard_bounds
+
+    def _is_outside_bounds(self, normalized_filter):
+        """Check if a normalized filter range extends outside hard_bounds."""
+        if not self._hard_bounds:
+            return False
+        bounds_min = self._resolve_bound(self._hard_bounds.get("min"), True)
+        bounds_max = self._resolve_bound(self._hard_bounds.get("max"), False)
+        start, end = normalized_filter["start"], normalized_filter["end"]
+        return (start and bounds_min and start < bounds_min) or (
+            end and bounds_max and end > bounds_max
+        )
 
     _FORMAT_SLICE = {
         "yyyy": 4,

--- a/tests/services/test_service_date_facet.py
+++ b/tests/services/test_service_date_facet.py
@@ -345,6 +345,8 @@ def test_date_facet_normalize_value():
     assert {
         "start": "2020-01-01",
         "end": "2020-12-31",
+        "start_raw": "2020",
+        "end_raw": "2020",
         "start_inclusive": True,
         "end_inclusive": True,
     } == normalized
@@ -352,6 +354,8 @@ def test_date_facet_normalize_value():
     assert {
         "start": None,
         "end": "2020-12-31",
+        "start_raw": None,
+        "end_raw": "2020",
         "start_inclusive": True,
         "end_inclusive": True,
     } == normalized
@@ -360,6 +364,8 @@ def test_date_facet_normalize_value():
     assert {
         "start": "2019-01-01",
         "end": None,
+        "start_raw": "2019",
+        "end_raw": None,
         "start_inclusive": True,
         "end_inclusive": True,
     } == normalized
@@ -385,6 +391,70 @@ def test_date_facet_last_day_of_month():
     assert 29 == DateFacet._last_day_of_month(2020, 2)
     assert 28 == DateFacet._last_day_of_month(2019, 2)
     assert 31 == DateFacet._last_day_of_month(2021, 12)
+
+
+def test_date_facet_range_query_uses_date_math():
+    """Range queries use ||/y, ||/M, ||/d rounding so exclusive bounds work."""
+    facet = DateFacet(field="date", label="Date")
+
+    # Inclusive year: gte rounds down to start of year
+    q = facet._build_range_query("[2020..2025]").to_dict()["range"]["date"]
+    assert q["gte"] == "2020||/y"
+    assert q["lte"] == "2025||/y"
+
+    # Exclusive year: gt rounds up to next year, lt rounds down to previous
+    q = facet._build_range_query("(2020..2025)").to_dict()["range"]["date"]
+    assert q["gt"] == "2020||/y"
+    assert q["lt"] == "2025||/y"
+
+    # Mixed precision
+    q = facet._build_range_query("2020-03..2020-03-15").to_dict()["range"]["date"]
+    assert q["gte"] == "2020-03||/M"
+    assert q["lte"] == "2020-03-15||/d"
+
+
+def test_date_facet_effective_date_respects_inclusivity():
+    """Effective dates shift by one period for exclusive bounds."""
+    facet = DateFacet(field="date", label="Date")
+
+    # (1970..]: exclusive year start → effective start is 1971-01-01
+    r = facet._normalize_value("(1970..]")
+    assert facet._effective_date(r, is_start=True) == "1971-01-01"
+
+    # [1970..]: inclusive year start → effective start is 1970-01-01
+    r = facet._normalize_value("[1970..]")
+    assert facet._effective_date(r, is_start=True) == "1970-01-01"
+
+    # [..1970): exclusive year end → effective end is 1969-12-31
+    r = facet._normalize_value("[..1970)")
+    assert facet._effective_date(r, is_start=False) == "1969-12-31"
+
+    # Month-precision exclusive end (2020-03 excluded → end is Feb 2020)
+    r = facet._normalize_value("[..2020-03)")
+    assert facet._effective_date(r, is_start=False) == "2020-02-29"
+
+    # Day-precision exclusive start (2020-03-15 excluded → starts 2020-03-16)
+    r = facet._normalize_value("(2020-03-15..]")
+    assert facet._effective_date(r, is_start=True) == "2020-03-16"
+
+
+def test_date_facet_outside_bounds_with_exclusive():
+    """Exclusive bounds at the edge of hard_bounds are NOT outside."""
+    bounds = {"min": "1970", "max": "now/y"}
+
+    def is_outside(filter_value):
+        f = DateFacet(field="date", label="Date", hard_bounds=bounds.copy())
+        f.prepare_aggregation([filter_value])
+        return f._is_outside_bounds(f._normalize_value(filter_value))
+
+    # (1969..]: exclusive of 1969 → effective start 1970 → at boundary, NOT outside
+    assert not is_outside("(1969..]")
+    # [1969..]: inclusive → effective start 1969 → before boundary, outside
+    assert is_outside("[1969..]")
+    # [1970..]: at boundary, NOT outside
+    assert not is_outside("[1970..]")
+    # (1968..]: exclusive of 1968 → effective start 1969 → still outside
+    assert is_outside("(1968..]")
 
 
 def test_date_facet_post_filter():

--- a/tests/services/test_service_date_facet.py
+++ b/tests/services/test_service_date_facet.py
@@ -419,34 +419,45 @@ def test_date_facet_hard_bounds_aggregation():
 
 
 def test_date_facet_effective_bounds():
-    """Effective bounds adjust when filter extends outside configured bounds."""
-    bounds = {"min": "1800", "max": "now/y"}
+    """Effective bounds depend on match_filter_bounds and the active filter."""
+    bounds = {"min": "1970", "max": "now/y"}
 
-    def make_facet(filter_value):
-        f = DateFacet(field="date", label="Date", hard_bounds=bounds.copy())
+    def make_facet(filter_value, match=False):
+        f = DateFacet(
+            field="date",
+            label="Date",
+            hard_bounds=bounds.copy(),
+            match_filter_bounds=match,
+        )
         f.prepare_aggregation([filter_value])
         return f._effective_bounds()
 
-    # Within bounds — unchanged
-    assert make_facet("2020..2025") == {"min": "1800", "max": "now/y"}
+    # No filter — configured bounds preserved
+    for match in (False, True):
+        facet = DateFacet(
+            field="date",
+            label="Date",
+            hard_bounds=bounds.copy(),
+            match_filter_bounds=match,
+        )
+        assert facet._effective_bounds() == bounds
 
-    # Entirely below min — replaced with filter range
+    # Default (match_filter_bounds=False): inside-bound filter keeps configured bounds
+    assert make_facet("2000..2025") == {"min": "1970", "max": "now/y"}
+    # Default: outside-bound filter replaces with filter range
     assert make_facet("1500..1700") == {"min": "1500", "max": "1700"}
-
-    # Crossing min — replaced with filter range
     assert make_facet("1500..2020") == {"min": "1500", "max": "2020"}
 
-    # Above max but "now/y" is never exceeded
-    assert make_facet("2020..3000") == {"min": "1800", "max": "now/y"}
-
-    # Open-ended range below min
-    assert make_facet("1500..") == {"min": "1500"}
+    # match_filter_bounds=True: filter range always used
+    assert make_facet("2000..2025", match=True) == {"min": "2000", "max": "2025"}
+    assert make_facet("1500..1700", match=True) == {"min": "1500", "max": "1700"}
+    assert make_facet("1500..", match=True) == {"min": "1500"}
 
     # No mutation of original _hard_bounds
     facet = DateFacet(field="date", label="Date", hard_bounds=bounds.copy())
     facet.prepare_aggregation(["1500..1700"])
     facet._effective_bounds()
-    assert facet._hard_bounds == {"min": "1800", "max": "now/y"}
+    assert facet._hard_bounds == bounds
 
 
 def test_date_facet_format_bound():


### PR DESCRIPTION
* Fixed a bug where filter values like ``0190..0500`` were passed as ``190-01-01`` / ``500-12-31`` to the query, causing OpenSearch to error with "failed to parse date field" since strict ISO requires a 4-digit year.
* Add ``match_filter_bounds`` flag to control how ``hard_bounds`` interacts with the active filter.
* Default ``False`` keeps the configured bounds when the filter is inside; replaces with the filter range when outside.
* Set to ``True`` to always use the filter range when a filter is active, focusing the histogram on the user's selection.
---

## Behavior demo

### `match_filter_bounds=True` (i.e. the default behavior)

<img width="630" height="730" alt="CleanShot 2026-04-29 at 09 02 33" src="https://github.com/user-attachments/assets/b6766d20-82b0-4067-bd94-126f43c60d09" />

### `match_filter_bounds=False`

<img width="630" height="730" alt="CleanShot 2026-04-29 at 09 05 59" src="https://github.com/user-attachments/assets/4eb6aa4a-d68d-4ad7-9c0c-1b10a785f7ba" />
