### PR TITLE
service: add support for search parameters (e.g. size, scroll, etc.)

### DIFF
--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -128,6 +128,7 @@ class RecordService(Service, RecordIndexerMixin):
         preference=None,
         extra_filter=None,
         versioning=True,
+        size=None,
         scroll=None,
     ):
         """Instantiate a search class."""
@@ -161,6 +162,9 @@ class RecordService(Service, RecordIndexerMixin):
                 .params(version=True)
             )
 
+        if size:
+            search = search.params(size=size)
+
         if scroll:
             search = search.params(scroll=scroll)
 
@@ -181,6 +185,7 @@ class RecordService(Service, RecordIndexerMixin):
         extra_filter=None,
         permission_action="read",
         versioning=True,
+        size=None,
         scroll=None,
     ):
         """Factory for creating a Search DSL instance."""
@@ -192,6 +197,7 @@ class RecordService(Service, RecordIndexerMixin):
             preference=preference,
             extra_filter=extra_filter,
             versioning=versioning,
+            size=size,
             scroll=scroll,
         )
 
@@ -212,6 +218,7 @@ class RecordService(Service, RecordIndexerMixin):
         extra_filter=None,
         permission_action="read",
         versioning=True,
+        size=None,
         scroll=None,
         **kwargs,
     ):
@@ -233,6 +240,7 @@ class RecordService(Service, RecordIndexerMixin):
             extra_filter=extra_filter,
             permission_action=permission_action,
             versioning=versioning,
+            size=size,
             scroll=scroll,
         )
 

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -126,10 +126,9 @@ class RecordService(Service, RecordIndexerMixin):
         search_opts,
         permission_action="read",
         preference=None,
+        search_params=None,
         extra_filter=None,
         versioning=True,
-        size=None,
-        scroll=None,
     ):
         """Instantiate a search class."""
         if permission_action:
@@ -162,11 +161,9 @@ class RecordService(Service, RecordIndexerMixin):
                 .params(version=True)
             )
 
-        if size:
-            search = search.params(size=size)
-
-        if scroll:
-            search = search.params(scroll=scroll)
+        # This can be used to pass search parameters like `size`, `scroll`, etc.
+        if search_params:
+            search = search.params(**search_params)
 
         # Extras
         extras = {}
@@ -182,11 +179,10 @@ class RecordService(Service, RecordIndexerMixin):
         record_cls,
         search_opts,
         preference=None,
+        search_params=None,
         extra_filter=None,
         permission_action="read",
         versioning=True,
-        size=None,
-        scroll=None,
     ):
         """Factory for creating a Search DSL instance."""
         search = self.create_search(
@@ -195,10 +191,9 @@ class RecordService(Service, RecordIndexerMixin):
             search_opts,
             permission_action=permission_action,
             preference=preference,
+            search_params=search_params,
             extra_filter=extra_filter,
             versioning=versioning,
-            size=size,
-            scroll=scroll,
         )
 
         # Run search args evaluator
@@ -213,13 +208,12 @@ class RecordService(Service, RecordIndexerMixin):
         identity,
         params,
         search_preference,
+        search_params=None,
         record_cls=None,
         search_opts=None,
         extra_filter=None,
         permission_action="read",
         versioning=True,
-        size=None,
-        scroll=None,
         **kwargs,
     ):
         """Create the search engine DSL."""
@@ -237,11 +231,10 @@ class RecordService(Service, RecordIndexerMixin):
             record_cls or self.record_cls,
             search_opts or self.config.search,
             preference=search_preference,
+            search_params=search_params,
             extra_filter=extra_filter,
             permission_action=permission_action,
             versioning=versioning,
-            size=size,
-            scroll=scroll,
         )
 
         # Run components
@@ -276,7 +269,13 @@ class RecordService(Service, RecordIndexerMixin):
         )
 
     def scan(
-        self, identity, params=None, search_preference=None, expand=False, **kwargs
+        self,
+        identity,
+        params=None,
+        search_preference=None,
+        search_params=None,
+        expand=False,
+        **kwargs,
     ):
         """Scan for records matching the querystring."""
         self.require_permission(identity, "search")
@@ -284,7 +283,7 @@ class RecordService(Service, RecordIndexerMixin):
         # Prepare and execute the search as scan()
         params = params or {}
         search_result = self._search(
-            "scan", identity, params, search_preference, **kwargs
+            "scan", identity, params, search_preference, search_params, **kwargs
         ).scan()
 
         return self.result_list(

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -128,6 +128,7 @@ class RecordService(Service, RecordIndexerMixin):
         preference=None,
         extra_filter=None,
         versioning=True,
+        scroll=None,
     ):
         """Instantiate a search class."""
         if permission_action:
@@ -160,6 +161,9 @@ class RecordService(Service, RecordIndexerMixin):
                 .params(version=True)
             )
 
+        if scroll:
+            search = search.params(scroll=scroll)
+
         # Extras
         extras = {}
         extras["track_total_hits"] = True
@@ -177,6 +181,7 @@ class RecordService(Service, RecordIndexerMixin):
         extra_filter=None,
         permission_action="read",
         versioning=True,
+        scroll=None,
     ):
         """Factory for creating a Search DSL instance."""
         search = self.create_search(
@@ -187,6 +192,7 @@ class RecordService(Service, RecordIndexerMixin):
             preference=preference,
             extra_filter=extra_filter,
             versioning=versioning,
+            scroll=scroll,
         )
 
         # Run search args evaluator
@@ -206,6 +212,7 @@ class RecordService(Service, RecordIndexerMixin):
         extra_filter=None,
         permission_action="read",
         versioning=True,
+        scroll=None,
         **kwargs,
     ):
         """Create the search engine DSL."""
@@ -226,6 +233,7 @@ class RecordService(Service, RecordIndexerMixin):
             extra_filter=extra_filter,
             permission_action=permission_action,
             versioning=versioning,
+            scroll=scroll,
         )
 
         # Run components


### PR DESCRIPTION
Add support for the `scroll` duration parameter.
By default, [`opensearch-py` sets a value a `5m` (5 minutes)](https://github.com/opensearch-project/opensearch-py/blob/v2.8.0/opensearchpy/_async/helpers/actions.py#L318), but setting a higher value might be useful for slow queries.