### PR TITLE
fix(tests): Added alembic test

### DIFF
--- a/tests/mock_module/api.py
+++ b/tests/mock_module/api.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2020-2023 CERN.
 # Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -41,7 +42,7 @@ class Record(RecordBase):
     """Example record API."""
 
     # Configuration
-    model_cls = models.RecordMetadata
+    model_cls = models.MockRecordMetadata
 
     # Model fields
     expires_at = ModelField()

--- a/tests/mock_module/models.py
+++ b/tests/mock_module/models.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
 # Copyright (C) 2025 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -20,7 +21,12 @@ from sqlalchemy_utils.types import ChoiceType, UUIDType
 from invenio_records_resources.records.models import FileRecordModelMixin
 
 
-class RecordMetadata(db.Model, RecordMetadataBase):
+#
+# Note: as we test alembic together with sqlalchemy-continuum, they get confused
+# if classes have the same name. Because RecordMetadata is already used in invenio-records
+# we call this class MockRecordMetadata to differentiate.
+#
+class MockRecordMetadata(db.Model, RecordMetadataBase):
     """Model for mock module metadata."""
 
     __tablename__ = "mock_metadata"
@@ -43,6 +49,6 @@ class RecordMetadataWithPID(db.Model, RecordMetadataBase):
 class FileRecordMetadata(db.Model, RecordMetadataBase, FileRecordModelMixin):
     """Model for mock module record files."""
 
-    __record_model_cls__ = RecordMetadata
+    __record_model_cls__ = MockRecordMetadata
 
     __tablename__ = "mock_record_files"

--- a/tests/records/test_systemfield_pid.py
+++ b/tests/records/test_systemfield_pid.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020-2025 Northwestern University.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio-Records-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -16,7 +17,7 @@ from invenio_records_resources.records.api import Record as RecordBase
 from invenio_records_resources.records.systemfields import PIDField
 from invenio_records_resources.records.systemfields.pid import PIDFieldContext
 from tests.mock_module.api import Record
-from tests.mock_module.models import RecordMetadata
+from tests.mock_module.models import MockRecordMetadata
 
 
 def test_class_attribute_access():
@@ -39,7 +40,7 @@ def test_create_no_provider(base_app, db):
     """Test creation without a provider."""
 
     class Record(RecordBase):
-        model_cls = RecordMetadata
+        model_cls = MockRecordMetadata
         pid = PIDField()
 
     record = Record.create({})
@@ -59,7 +60,7 @@ def test_create_different_key(base_app, db):
     """Test creation with different key."""
 
     class Record(RecordBase):
-        model_cls = RecordMetadata
+        model_cls = MockRecordMetadata
         pid = PIDField("pid.id", provider=RecordIdProviderV2)
 
     record = Record.create({})

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2026 CESNET z.s.p.o.
+#
+# Invenio-records-resources is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Test invenio-records-resources alembic."""
+
+import pytest
+from invenio_db.utils import alembic_test_context, drop_alembic_version_table
+
+
+def test_alembic(app, db, extra_entry_points):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    if db.engine.name == "sqlite":
+        raise pytest.skip("Upgrades are not supported on SQLite.")
+
+    app.config["ALEMBIC_CONTEXT"] = alembic_test_context()
+
+    # Check that this package's SQLAlchemy models have been properly registered
+    tables = [x for x in db.metadata.tables]
+    assert "files_location" in tables
+    assert "files_bucket" in tables
+
+    def assert_no_unexpected_migrations():
+        # names created by RecordTypeFactory in tests and registered to sqlalchemy
+        extra_names = [
+            "grant_metadata",
+            "granttest_metadata",
+            "license_metadata",
+            "myrecord_metadata",
+            "optionalendpoint_metadata",
+            "optionalindex_metadata",
+            "optionalschemapath_metadata",
+            "optionalversion_metadata",
+            "recordcls_metadata",
+            "resourcetest_metadata",
+            "searchfacets_metadata",
+            "servicetest_metadata",
+        ]
+        unexpected_migrations = [
+            m
+            for m in ext.alembic.compare_metadata()
+            if "mock" not in m[1].name.lower() and m[1].name.lower() not in extra_names
+        ]
+        assert unexpected_migrations == []
+
+    # Check that Alembic agrees that there's no further tables to create.
+    assert_no_unexpected_migrations()
+
+    # Drop everything and recreate tables all with Alembic
+    db.drop_all()
+    drop_alembic_version_table()
+    ext.alembic.upgrade()
+
+    assert_no_unexpected_migrations()
+
+    drop_alembic_version_table()


### PR DESCRIPTION
### Description

* Added test for alembic forward migrations
* Needed to rename mock class RecordMetadata to MockRecordMetadata 
  due to name conflict with invenio-records

Reason in detail for the renaming:

`tests/mock_module/models.py` defined a class also named `RecordMetadata`,
colliding with `invenio_records.models.RecordMetadata`.  SQLAlchemy's
declarative registry (`registry._class_registry` in `sqlalchemy/orm/clsregistry.py`)
replaces duplicate names with a `_MultipleClassMarker` sentinel, which has no
`__table__` attribute.  `sqlalchemy_utils.get_class_by_table()` finds classes
by iterating registry values and checking `c.__table__ is table` — so both
`RecordMetadata` classes become invisible, and the function returns `None` for
the `records_metadata` table.

`invenio_db`'s `init_versioning` (`invenio_db/ext.py`) calls
`builder.instrument_versioned_classes(mapper, get_class_by_table(...))` for
every table already in `db.metadata`.  When it receives `None` for
`records_metadata`, sqlalchemy-continuum silently skips versioning that table,
so `db.create_all()` never creates `records_metadata_version` or its indices.
The Alembic migrations *do* create them, so `compare_metadata()` reports
spurious `remove_index`/`remove_table` diffs.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
