### PR TITLE
fix: use key if label not found

### DIFF
--- a/invenio_records_resources/services/records/facets/facets.py
+++ b/invenio_records_resources/services/records/facets/facets.py
@@ -90,7 +90,7 @@ class LabelledFacetMixin:
                 {
                     "key": key,
                     "doc_count": self.get_metric(bucket),
-                    "label": label_map[key],
+                    "label": label_map[key] if key in label_map else key,
                     "is_selected": self.is_filtered(key, filter_values),
                 }
             )
@@ -251,7 +251,7 @@ class NestedTermsFacet(TermsFacet):
             bucket_out = {
                 "key": key,
                 "doc_count": self.get_metric(bucket),
-                "label": label_map[key],
+                "label": label_map[key] if key in label_map else key,
                 "is_selected": self.is_filtered(full_key, filter_values),
             }
             if "inner" in bucket:

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -126,7 +126,7 @@ def test_file_flow(file_service, location, example_file_record, identity_simple,
         content,
         content.getbuffer().nbytes,
     )
-    # TODO figure response for succesfully saved file
+    # TODO figure response for successfully saved file
     assert result.to_dict()["key"] == file_to_initialise[0]["key"]
 
     result = file_service.commit_file(identity_simple, recid, "article.txt")


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

* currently if the key is not found the search results page does not load at all

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
