### PR TITLE
Refactor(schema): Update record schemas for singleton reuse

### DIFF
--- a/invenio_records_resources/ext.py
+++ b/invenio_records_resources/ext.py
@@ -9,7 +9,12 @@ from functools import cached_property
 from invenio_base.utils import obj_or_import_string
 
 from . import config
-from .registry import NotificationRegistry, ServiceRegistry
+from .registry import (
+    CustomFieldsSchemaRegistry,
+    GlobalSchemaRegistry,
+    NotificationRegistry,
+    ServiceRegistry,
+)
 
 
 class InvenioRecordsResources(object):
@@ -26,6 +31,8 @@ class InvenioRecordsResources(object):
         self.init_config(app)
         self.registry = ServiceRegistry()
         self.notification_registry = NotificationRegistry()
+        self.custom_fields_schema_registry = CustomFieldsSchemaRegistry()
+        self.global_schema_registry = GlobalSchemaRegistry()
         app.extensions["invenio-records-resources"] = self
 
     @cached_property

--- a/invenio_records_resources/proxies.py
+++ b/invenio_records_resources/proxies.py
@@ -21,3 +21,15 @@ current_notifications_registry = LocalProxy(
 current_transfer_registry = LocalProxy(
     lambda: current_app.extensions["invenio-records-resources"].transfer_registry
 )
+
+current_custom_fields_schema_registry = LocalProxy(
+    lambda: current_app.extensions[
+        "invenio-records-resources"
+    ].custom_fields_schema_registry
+)
+"""Helper proxy to get the current custom fields schema registry."""
+
+current_global_schema_registry = LocalProxy(
+    lambda: current_app.extensions["invenio-records-resources"].global_schema_registry
+)
+"""Helper proxy to get the current global schema registry."""

--- a/invenio_records_resources/registry.py
+++ b/invenio_records_resources/registry.py
@@ -3,6 +3,8 @@
 
 """Invenio-Records-Resources registry."""
 
+from .services.custom_fields.schema import CustomFieldsSchema, CustomFieldsSchemaUI
+
 
 class ServiceRegistry:
     """A simple class to register services."""
@@ -53,3 +55,36 @@ class NotificationRegistry:
         Returns an empty list if not found.
         """
         return self._handlers.get(record_type, [])
+
+
+class GlobalSchemaRegistry:
+    """A global registry for cached schemas."""
+
+    def __init__(self):
+        """Initialize the registry."""
+        self._schemas = {}
+
+    def get(self, schema_cls):
+        """Get a cached schema."""
+        if schema_cls not in self._schemas:
+            self._schemas[schema_cls] = schema_cls()
+        return self._schemas[schema_cls]
+
+
+class CustomFieldsSchemaRegistry:
+    """A registry for custom fields schemas."""
+
+    def __init__(self):
+        """Initialize the registry."""
+        self._schemas = {}
+
+    def register(self, app, fields_var, schema_cls):
+        """Register a new custom fields schema."""
+        field_property_name = schema_cls.field_property_name
+        config = app.config.get(fields_var, [])
+        self._schemas.setdefault(fields_var, {})
+        self._schemas[fields_var].setdefault(field_property_name, schema_cls(config))
+
+    def get(self, fields_var, field_property_name):
+        """Get a custom fields schema by fields variable and field property name."""
+        return self._schemas[fields_var][field_property_name]

--- a/invenio_records_resources/services/custom_fields/schema.py
+++ b/invenio_records_resources/services/custom_fields/schema.py
@@ -3,7 +3,6 @@
 
 """Custom Fields schema for InvenioRDM."""
 
-from flask import current_app
 from marshmallow import Schema
 
 
@@ -15,10 +14,9 @@ class CustomFieldsSchema(Schema):
 
     field_property_name = "field"
 
-    def __init__(self, fields_var, *args, **kwargs):
+    def __init__(self, config, *args, **kwargs):
         """constructor."""
         super().__init__(*args, **kwargs)
-        config = current_app.config.get(fields_var, [])
         self.fields = {
             field.name: getattr(field, self.field_property_name) for field in config
         }

--- a/invenio_records_resources/services/files/components/metadata.py
+++ b/invenio_records_resources/services/files/components/metadata.py
@@ -44,8 +44,7 @@ class FileMetadataComponent(FileServiceComponent):
 
     def update_file_metadata(self, identity, id_, file_key, record, data):
         """Update file metadata handler."""
-        schema = self.service.file_schema.schema(many=False)
-        validated_data = schema.load(data)
+        validated_data, errors = self.service.file_schema.load(data, raise_errors=True)
         record.files.update(file_key, data=validated_data)
 
     def update_transfer_metadata(

--- a/invenio_records_resources/services/files/schema.py
+++ b/invenio_records_resources/services/files/schema.py
@@ -12,6 +12,7 @@ from typing import Mapping
 from marshmallow import RAISE, Schema, ValidationError, post_dump, pre_load
 from marshmallow.fields import UUID, Boolean, Dict, Integer, Nested, Str
 from marshmallow_oneofschema import OneOfSchema
+from marshmallow_utils.context import context_schema
 from marshmallow_utils.fields import GenMethod, Links, TZDateTime
 
 from ...proxies import current_transfer_registry
@@ -103,13 +104,13 @@ class FileSchema(Schema):
     size = Integer(dump_only=True)
     transfer = Nested(TransferSchema, dump_only=True)
     status = GenMethod("dump_status")
-    transfer = Nested(TransferSchema, dump_only=True)
 
     def dump_status(self, obj):
         """Dump file status."""
+        ctx = context_schema.get()
         transfer = current_transfer_registry.get_transfer(
             file_record=obj,
-            file_service=self.context.get("service"),
+            file_service=ctx.get("service"),
             record=obj.record,
         )
         return transfer.status

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -172,8 +172,9 @@ class FileService(Service):
         # if user has permission for the transfer type that is on
         # each of the uploaded files. This is done in the IfTransferType
         # permission generator.
-        schema = self.initial_file_schema.schema(many=True)
-        data = schema.load(data)
+        data, _ = self.initial_file_schema.load(
+            data, schema_args={"many": True}, raise_errors=True
+        )
 
         if not data:
             raise ValidationError("No files to upload.")

--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -14,6 +14,7 @@ from marshmallow_utils.context import context_schema
 from marshmallow_utils.fields import Links, TZDateTime
 
 from invenio_records_resources.errors import validation_error_to_list_errors
+from invenio_records_resources.proxies import current_global_schema_registry
 
 
 #
@@ -59,7 +60,8 @@ class ServiceSchemaWrapper:
 
     def __init__(self, service, schema):
         """Constructor."""
-        self.schema = schema
+        self._schema_cls = schema
+        self._schema = current_global_schema_registry.get(schema)
         # TODO: Change constructor to accept a permission_policy_cls directly
         self._permission_policy_cls = service.config.permission_policy_cls
 
@@ -89,7 +91,7 @@ class ServiceSchemaWrapper:
 
         token = context_schema.set(local_context)
         try:
-            valid_data = self.schema(**schema_args).load(data)
+            valid_data = self._schema.load(data, **schema_args)
             errors = []
         except ValidationError as e:
             if raise_errors:
@@ -110,6 +112,15 @@ class ServiceSchemaWrapper:
 
         token = context_schema.set(local_context)
         try:
-            return self.schema(**schema_args).dump(data)
+            return self._schema.dump(data, **schema_args)
         finally:
             context_schema.reset(token)
+
+    def schema(self, **schema_args):
+        """
+        Return the schema for the service.
+
+        The schema_args are (and should be) passed to the load and dump methods directly so the schema is not instantiated again.
+        It is passed here for backwards compatibility.
+        """
+        return self._schema

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -5,6 +5,8 @@
 
 """Record Service API."""
 
+from functools import cached_property
+
 from flask import current_app
 from invenio_db import db
 from invenio_pidstore.errors import PIDDoesNotExistError
@@ -69,7 +71,7 @@ class RecordService(Service, RecordIndexerMixin):
     # Low-level API
     #
 
-    @property
+    @cached_property
     def schema(self):
         """Returns the data schema instance."""
         return ServiceSchemaWrapper(self, schema=self.config.schema)

--- a/tests/services/custom_fields/test_schema_cf.py
+++ b/tests/services/custom_fields/test_schema_cf.py
@@ -30,7 +30,7 @@ def app_config(app_config):
 
 
 def test_cf_schema(app):
-    schema = CustomFieldsSchema("RECORDS_RESOURCES_CUSTOM_CONFIG")
+    schema = CustomFieldsSchema(app.config["RECORDS_RESOURCES_CUSTOM_CONFIG"])
     assert schema.load(
         {
             "myorg:txt": "some",


### PR DESCRIPTION
closes: https://github.com/inveniosoftware/invenio-app-rdm/issues/3480

This PR updates the core records schema layer so marshmallow schemas can be reused safely, instead of being recreated on every service call.

- Schema instances are cached and reused via a global schema cache (get_cached_schema), so load/dump no longer build a fresh schema tree on every request.
- CustomFieldsSchema is built once at app startup through CustomFieldsSchemaRegistry, using config resolved in init_app() rather than at import time.

---

Optional (for testing) - **Currently with these optimizations it may not be needed in the end, keeping in mind the future move to marshmallow v4 should also better the performance further.**

For adding DFM (DeepFriedMarshmallow), add sitecustomize.py inside the `site/` folder of your instance
```
import re
import deepfriedmarshmallow.jit as dfm_jit
from deepfriedmarshmallow import deep_fry_marshmallow
from marshmallow import fields
from deepfriedmarshmallow.jit.plugins import register_field_inliner_factory

dfm_jit._VALID_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")

def _constant_inliner_fixed(field_obj, context):
    if not isinstance(field_obj, fields.Constant):
        return None
    sym = f"__dfm_const_{id(field_obj)}"
    context.namespace[sym] = field_obj.constant
    return sym if context.is_serializing else None

register_field_inliner_factory(_constant_inliner_fixed)

deep_fry_marshmallow()
```

Because there is some punting done by the creator, so this is to work around it for now just for testing.