### PR TITLE
fix: report FAILED status when multipart upload no longer exists in storage

### DIFF
--- a/invenio_records_resources/services/files/transfer/providers/multipart.py
+++ b/invenio_records_resources/services/files/transfer/providers/multipart.py
@@ -4,6 +4,7 @@
 
 """Multipart file transfer provider."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 import marshmallow as ma
@@ -14,11 +15,11 @@ from invenio_files_rest.models import FileInstance, ObjectVersion
 from ....errors import TransferException
 from ....uow import RecordCommitOp, TaskOp
 from ...schema import BaseTransferSchema
-from ...tasks import (
-    recompute_multipart_checksum_task,
-)
+from ...tasks import recompute_multipart_checksum_task
 from ..base import Transfer, TransferStatus
 from ..constants import LOCAL_TRANSFER_TYPE, MULTIPART_TRANSFER_TYPE
+
+logger = logging.getLogger(__name__)
 
 
 class MultipartStorageExt:
@@ -122,6 +123,18 @@ class MultipartStorageExt:
         """
         if hasattr(self._storage, "multipart_abort_upload"):
             return self._storage.multipart_abort_upload(**multipart_metadata)
+
+    def multipart_upload_exists(self, **multipart_metadata):
+        """Return True if the multipart upload is still active in the storage backend.
+
+        Returns True for backends that do not implement this check (safe default).
+
+        :param multipart_metadata: The metadata returned by multipart_initialize_upload.
+        :returns: True if the upload is still active (or unknown), False if gone.
+        """
+        if hasattr(self._storage, "multipart_upload_exists"):
+            return self._storage.multipart_upload_exists(**multipart_metadata)
+        return True
 
     def multipart_links(self, base_url, **multipart_metadata):
         """
@@ -312,9 +325,21 @@ class MultipartTransfer(Transfer):
 
     @property
     def status(self):
-        """Get the status of the transfer."""
-        # if the storage_class is M, return pending
-        # after commit, the storage class is changed to L (same way as FETCH works)
+        """Get the status of the transfer.
+
+        Returns FAILED if the storage backend confirms the multipart upload no longer
+        exists (e.g. aborted or expired in S3). Returns PENDING otherwise.
+        """
+        try:
+            storage = self._get_storage()
+            if not storage.multipart_upload_exists(**self.multipart_metadata):
+                return TransferStatus.FAILED
+        except Exception:
+            logger.warning(
+                "Could not check multipart upload existence for file %s; assuming pending.",
+                self.file_record.key,
+                exc_info=True,
+            )
         return TransferStatus.PENDING
 
     def expand_links(self, identity, self_url):


### PR DESCRIPTION
## What does this PR do?

When a presigned direct-to-S3 multipart upload is abandoned (browser crash, network failure, upload timeout), the file record stays stuck in `"pending"` state forever. The user has no way to tell something went wrong, and the only fix is admin intervention.

This PR overrides `MultipartTransfer.status` to ask the storage backend whether the multipart upload is still alive. If the backend confirms it is gone, `FAILED` is returned instead of `PENDING`, surfacing the error in the UI.

**Changes:**
- `MultipartStorageExt.multipart_upload_exists()` — new method that delegates to the storage backend. Returns `True` (safe default) for backends that don't implement it, preserving current behaviour on local/non-S3 storage.
- `MultipartTransfer.status` — checks `multipart_upload_exists()`; returns `FAILED` if the upload is confirmed gone, `PENDING` otherwise. Any exception during the check is logged and falls back to `PENDING`.

## Depends on

- `invenio-s3` PR inveniosoftware/invenio-s3#49 — implements `multipart_upload_exists()` and the graceful `NoSuchUpload` handling in `multipart_abort_upload`.

## Notes for reviewers

- The `FAILED` path is only reachable for storage backends that implement `multipart_upload_exists()`. All existing backends are unaffected.
- The extra S3 `list_parts` call happens only while a file is in `PENDING` state (type `M`). After `commit_file`, the transfer type changes to `L` and `MultipartTransfer.status` is no longer called.
- All existing tests continue to pass unchanged.