### PR TITLE
Reusable marshmallow schema instances in services

### DIFF
--- a/invenio_records_resources/services/files/components/metadata.py
+++ b/invenio_records_resources/services/files/components/metadata.py
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: 2021-2024 CERN.
+# SPDX-FileCopyrightText: 2021-2026 CERN.
 # SPDX-FileCopyrightText: 2025 CESNET.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Files metadata component components."""
@@ -44,8 +45,7 @@ class FileMetadataComponent(FileServiceComponent):
 
     def update_file_metadata(self, identity, id_, file_key, record, data):
         """Update file metadata handler."""
-        schema = self.service.file_schema.schema(many=False)
-        validated_data = schema.load(data)
+        validated_data, _errors = self.service.file_schema.load(data, raise_errors=True)
         record.files.update(file_key, data=validated_data)
 
     def update_transfer_metadata(

--- a/invenio_records_resources/services/files/schema.py
+++ b/invenio_records_resources/services/files/schema.py
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: 2020-2024 CERN.
+# SPDX-FileCopyrightText: 2020-2026 CERN.
 # SPDX-FileCopyrightText: 2020 European Union.
 # SPDX-FileCopyrightText: 2025 CESNET.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """File schema."""
@@ -12,6 +13,7 @@ from typing import Mapping
 from marshmallow import RAISE, Schema, ValidationError, post_dump, pre_load
 from marshmallow.fields import UUID, Boolean, Dict, Integer, Nested, Str
 from marshmallow_oneofschema import OneOfSchema
+from marshmallow_utils.context import context_schema
 from marshmallow_utils.fields import GenMethod, Links, TZDateTime
 
 from ...proxies import current_transfer_registry
@@ -25,7 +27,7 @@ class BaseTransferSchema(Schema):
     """
 
     type_ = Str(attribute="type", data_key="type", required=True)
-    """Transfer type. Required field, the initial transfer type is filled 
+    """Transfer type. Required field, the initial transfer type is filled
     automatically by the InitFileSchema."""
 
     class Meta:
@@ -103,13 +105,13 @@ class FileSchema(Schema):
     size = Integer(dump_only=True)
     transfer = Nested(TransferSchema, dump_only=True)
     status = GenMethod("dump_status")
-    transfer = Nested(TransferSchema, dump_only=True)
 
     def dump_status(self, obj):
         """Dump file status."""
+        ctx = context_schema.get()
         transfer = current_transfer_registry.get_transfer(
             file_record=obj,
-            file_service=self.context.get("service"),
+            file_service=ctx.get("service"),
             record=obj.record,
         )
         return transfer.status

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2020-2026 CERN.
 # SPDX-FileCopyrightText: 2020-2021 Northwestern University.
 # SPDX-FileCopyrightText: 2025 CESNET i.a.l.e.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """File Service API."""
@@ -172,8 +173,9 @@ class FileService(Service):
         # if user has permission for the transfer type that is on
         # each of the uploaded files. This is done in the IfTransferType
         # permission generator.
-        schema = self.initial_file_schema.schema(many=True)
-        data = schema.load(data)
+        data, _ = self.initial_file_schema.load(
+            data, schema_args={"many": True}, raise_errors=True
+        )
 
         if not data:
             raise ValidationError("No files to upload.")

--- a/invenio_records_resources/services/files/service.py
+++ b/invenio_records_resources/services/files/service.py
@@ -28,6 +28,23 @@ from .schema import InitFileSchemaMixin
 class FileService(Service):
     """A service for adding files support to records."""
 
+    def __init__(self, config):
+        """Constructor."""
+        super().__init__(config)
+        self._file_schema = ServiceSchemaWrapper(self, schema=self.config.file_schema)
+        if not hasattr(self.config, "initial_file_schema"):
+            self.config.initial_file_schema = type(
+                self.config.file_schema.__name__ + "Initial",
+                (
+                    InitFileSchemaMixin,
+                    self.config.file_schema,
+                ),
+                {},
+            )
+        self._initial_file_schema = ServiceSchemaWrapper(
+            self, schema=self.config.initial_file_schema
+        )
+
     @property
     def record_cls(self):
         """Get the record class."""
@@ -41,21 +58,12 @@ class FileService(Service):
         For the creation of a new file, use the `initial_file_schema` property
         as it will include the necessary fields for initiating the file upload.
         """
-        return ServiceSchemaWrapper(self, schema=self.config.file_schema)
+        return self._file_schema
 
     @property
     def initial_file_schema(self):
         """Returns the data schema instance for initiating the file upload."""
-        if not hasattr(self.config, "initial_file_schema"):
-            self.config.initial_file_schema = type(
-                self.config.file_schema.__name__ + "Initial",
-                (
-                    InitFileSchemaMixin,
-                    self.config.file_schema,
-                ),
-                {},
-            )
-        return ServiceSchemaWrapper(self, schema=self.config.initial_file_schema)
+        return self._initial_file_schema
 
     def file_result_item(self, *args, **kwargs):
         """Create a new instance of the resource unit."""

--- a/invenio_records_resources/services/records/schema.py
+++ b/invenio_records_resources/services/records/schema.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2020-2024 CERN.
-# SPDX-FileCopyrightText: 2022 TU Wien.
+# SPDX-FileCopyrightText: 2020-2026 CERN.
+# SPDX-FileCopyrightText: 2022-2026 TU Wien.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
@@ -59,7 +59,8 @@ class ServiceSchemaWrapper:
 
     def __init__(self, service, schema):
         """Constructor."""
-        self.schema = schema
+        self._schema_cls = schema
+        self.schema = self._schema_cls()
         # TODO: Change constructor to accept a permission_policy_cls directly
         self._permission_policy_cls = service.config.permission_policy_cls
 
@@ -89,7 +90,7 @@ class ServiceSchemaWrapper:
 
         token = context_schema.set(local_context)
         try:
-            valid_data = self.schema(**schema_args).load(data)
+            valid_data = self.schema.load(data, **schema_args)
             errors = []
         except ValidationError as e:
             if raise_errors:
@@ -110,6 +111,6 @@ class ServiceSchemaWrapper:
 
         token = context_schema.set(local_context)
         try:
-            return self.schema(**schema_args).dump(data)
+            return self.schema.dump(data, **schema_args)
         finally:
             context_schema.reset(token)

--- a/invenio_records_resources/services/records/service.py
+++ b/invenio_records_resources/services/records/service.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2020-2024 CERN.
 # SPDX-FileCopyrightText: 2020 Northwestern University.
 # SPDX-FileCopyrightText: 2020 European Union.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Record Service API."""
@@ -65,14 +66,22 @@ class RecordIndexerMixin:
 class RecordService(Service, RecordIndexerMixin):
     """Record Service."""
 
+    def __init__(self, config):
+        """Constructor."""
+        super().__init__(config)
+        if schema := getattr(config, "schema", None):
+            self._schema = ServiceSchemaWrapper(self, schema=schema)
+        else:
+            self._schema = None
+
     #
     # Low-level API
     #
 
     @property
     def schema(self):
-        """Returns the data schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema)
+        """Return the data schema instance."""
+        return self._schema
 
     @property
     def components(self):


### PR DESCRIPTION
PR based on @sakshamarora1 's PR https://github.com/inveniosoftware/invenio-records-resources/pull/687 but without the schema registry (pulled the schema initialization into the service constructor instead).

This PR targets `maint-10.x` because I'm trying stuff out with a v14 setup.