### PR TITLE
Backport i18n fix

### DIFF
--- a/invenio_records_resources/services/errors.py
+++ b/invenio_records_resources/services/errors.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2020 Northwestern University.
 # SPDX-FileCopyrightText: 2023 Graz University of Technology.
 # SPDX-FileCopyrightText: 2025 CESNET i.a.l.e.
+# SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 
 """Errors."""
@@ -138,9 +139,9 @@ class FilesCountExceededException(Exception):
         """Constructor."""
         super().__init__(
             _(
-                "Uploading the selected files would result in {files_count} files (max is {max_files}).".format(
-                    max_files=max_files, files_count=resulting_files_count
-                )
+                "Uploading the selected files would result in %(files_count)s files (max is %(max_files)s).",
+                max_files=max_files,
+                files_count=resulting_files_count,
             )
         )
 

--- a/invenio_records_resources/services/files/transfer/providers/local.py
+++ b/invenio_records_resources/services/files/transfer/providers/local.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2021-2024 CERN.
 # SPDX-FileCopyrightText: 2025 CESNET.
+# SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
 
 """Local transfer provider."""
@@ -24,7 +25,10 @@ class LocalTransfer(Transfer):
         """Set file content."""
         if self.file_record.file is not None:
             raise TransferException(
-                _(f'File with key "{self.file_record.key}" is already committed.')
+                _(
+                    'File with key "%(file_key)s" is already committed.',
+                    file_key=self.file_record.key,
+                )
             )
 
         super().set_file_content(stream, content_length)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* backport: https://github.com/inveniosoftware/invenio-records-resources/pull/679
* related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3499



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
