### PR TITLE
fix: retry multipart checksum computation

### DIFF
--- a/invenio_records_resources/services/files/tasks.py
+++ b/invenio_records_resources/services/files/tasks.py
@@ -76,18 +76,30 @@ def fetch_file(service_id, record_id, file_key):
         raise
 
 
-@shared_task(ignore_result=True)
+@shared_task(
+    ignore_result=True,
+    acks_late=True,
+    retry_backoff=True,
+    max_retries=10,
+    autoretry_for=(Exception,),
+)
 def recompute_multipart_checksum_task(file_instance_id):
     """Create checksum for a single object from multipart upload."""
     try:
-        file_instance = FileInstance.query.filter_by(id=file_instance_id).one()
+        file_instance = FileInstance.query.filter_by(id=file_instance_id).one_or_none()
+        if not file_instance:
+            # the file instance has been already deleted, for example user has deleted the draft
+            # or removed the file from the draft
+            return
         checksum = file_instance.checksum
         if not checksum:
+            # multipart checksum not present -> compute normal checksum
             file_instance.update_checksum()
             db.session.add(file_instance)
             db.session.commit()
             return
         elif not checksum.startswith("multipart:"):
+            # checksum has already been computed, nothing to do
             return
 
         # multipart checksum looks like: multipart:<s3 multipart checksum>-part_size


### PR DESCRIPTION
### Description

This PR fixes a couple of bugs: 

1. network errors during md5 computation: if there is an error during computation of md5 checksum for multipart upload, the computation will never retry and the checksum will be forever "multipart:...". A fix is to retry the computation. 

2. container shutdown - if container is shut down during the computation, the message is never re-delivered. Added `acks_late` to ack the message after the computation has finished. 

3. if the file is removed before the computation starts, an exception was raised. Fixed by simply returning.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
