### PR TITLE
fix: handle non-UTF-8 encoded filenames in ZIP archives

### DIFF
--- a/invenio_records_resources/services/files/extractors/zip.py
+++ b/invenio_records_resources/services/files/extractors/zip.py
@@ -217,6 +217,22 @@ def make_generator(zip_ref, path):
     return generator()
 
 
+def _sanitize_filename(filename):
+    """Sanitize a filename by normalizing its encoding.
+
+    Converts the filename to UTF-8, ignoring any invalid byte sequences.
+    This handles cases where ZIP entries may have been encoded with
+    different character encodings (e.g., CP1252, ISO-8859-1).
+
+    Args:
+        filename: The filename to sanitize, potentially with non-UTF-8 bytes.
+
+    Returns:
+        A sanitized UTF-8 string with invalid characters removed.
+    """
+    return filename.encode("utf-8", errors="ignore").decode("utf-8")
+
+
 class ZipExtractor(FileExtractor):
     """
     Extractor for ZIP files that uses the cached position of table of contents for efficient extraction.
@@ -306,7 +322,7 @@ class ZipExtractor(FileExtractor):
             # Iterate through all entries in the ZIP's central directory
             # Recording Stream will capture byte range accessed
             for info in zip_file.infolist:
-                file_key = str(PurePosixPath(info.filename))
+                file_key = str(PurePosixPath(_sanitize_filename(info.filename)))
                 if info.is_dir():
                     directories.append({"key": file_key})
                 else:
@@ -352,9 +368,18 @@ class ZipExtractor(FileExtractor):
             None,
         )
         if not found_item:
-            raise FileKeyNotFoundError(file_record.record["id"], path)
+            found_item = next(
+                (
+                    item
+                    for item in zip_proxy.infolist
+                    if _sanitize_filename(item.filename.rstrip("/")) == path
+                ),
+                None,
+            )
+            if not found_item:
+                raise FileKeyNotFoundError(file_record.record["id"], path)
         if not found_item.is_dir():
-            return zip_proxy.open(path)
+            return zip_proxy.open(found_item.filename)
         else:
             return self._zip_directory(zip_proxy, found_item.filename)
 

--- a/invenio_records_resources/services/files/results.py
+++ b/invenio_records_resources/services/files/results.py
@@ -5,6 +5,7 @@
 
 """File service results."""
 
+import urllib.parse
 from collections import defaultdict
 from functools import cached_property
 from pathlib import Path
@@ -250,8 +251,25 @@ class ContainerItemResult(ServiceItemResult):
 
             chunk_iterator = generator()
 
+        # Use RFC 5987 encoding for UTF-8 filenames in Content-Disposition header
+        # This allows non-ASCII characters (like Czech č,ř,í, etc.) to be properly handled
+        try:
+            filename_ascii = filename.encode("ascii").decode("ascii")
+            # Filename is ASCII-only, use simple format
+            content_disposition = f'attachment; filename="{filename_ascii}"'
+        except UnicodeEncodeError:
+            # Filename contains non-ASCII characters, use RFC 5987 encoding
+            filename_encoded = urllib.parse.quote(filename, safe="", encoding="utf-8")
+            # Fallback filename with underscores for non-ASCII chars
+            filename_fallback = "".join(c if ord(c) < 128 else "_" for c in filename)
+
+            filename_fallback = urllib.parse.quote(
+                filename_fallback, safe="", encoding="utf-8"
+            )
+            content_disposition = f"attachment; filename=\"{filename_fallback}\"; filename*=UTF-8''{filename_encoded}"
+
         headers = {
-            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Disposition": content_disposition,
         }
         if self.size is not None:
             headers["Content-Length"] = str(self.size)

--- a/tests/services/files/test_zip.py
+++ b/tests/services/files/test_zip.py
@@ -1,6 +1,5 @@
 import io
 import zipfile
-from os.path import dirname, join
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,6 +7,64 @@ import pytest
 from invenio_records_resources.services.errors import InvalidFileContentError
 from invenio_records_resources.services.files.components import processor
 from invenio_records_resources.tasks import extract_file_metadata
+
+
+@pytest.fixture()
+def zip_with_non_ascii_filenames(
+    file_service, location, example_record, identity_simple, monkeypatch
+):
+    """Create a record with a ZIP file containing non-ASCII filenames.
+
+    The ZIP contains files with Unicode characters in filenames to test
+    proper handling of non-UTF-8 encoded filenames from various locales.
+    """
+    task = MagicMock()
+    monkeypatch.setattr(processor, "extract_file_metadata", task)
+
+    recid = example_record["id"]
+
+    # Create a ZIP file with non-ASCII filenames
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zipf:
+        # Add files with various non-ASCII characters in filenames
+        zipf.writestr("file_über.txt", "Content 1")
+        zipf.writestr("données_fichier.txt", "Content 2")
+        zipf.writestr("archivo_prueba_ñ.txt", "Content 3")
+    zip_buffer.seek(0)
+
+    metadata = {"type": "zip"}
+    file_service.init_files(
+        identity_simple,
+        recid,
+        data=[{"key": "non_ascii_test.zip", "metadata": metadata}],
+    )
+    file_service.set_file_content(
+        identity_simple, recid, "non_ascii_test.zip", zip_buffer
+    )
+    file_service.commit_file(identity_simple, recid, "non_ascii_test.zip")
+
+    # Call the metadata extraction task manually
+    extract_file_metadata(*task.apply_async.call_args[1]["args"])
+
+    return example_record
+
+
+def test_zip_open_non_ascii_filenames(
+    identity_simple, file_service, zip_with_non_ascii_filenames
+):
+    """Test that files with non-ASCII filenames can be opened correctly.
+
+    This verifies that the open() method can find and open files
+    with Unicode characters in their names.
+    """
+    recid = zip_with_non_ascii_filenames["id"]
+
+    # Open a file with non-ASCII characters
+    with file_service.open_container_item(
+        identity_simple, recid, "non_ascii_test.zip", "file_über.txt"
+    ) as f:
+        data = f.read()
+        assert data == b"Content 1"
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Description

Fix handling of ZIP files with non-ASCII filenames that use non-UTF-8 encodings.

Previously, ZIP entries containing filenames with characters outside ASCII (e.g., accented letters from various locales) could not be downloaded or previewed. This occurred when ZIP archives were created on systems using different character encodings (CP1252, ISO-8859-1, etc.).

**Changes**
Added _sanitize_filename() function to normalize filenames by converting to UTF-8 and ignoring invalid byte sequences
Updated ZipExtractor.list() to sanitize filenames when building the listing
Enhanced ZipExtractor.open() with fallback matching that sanitizes both stored names and lookup paths

**Limitations**
This is a temporary solution that may strip some characters from filenames. For v15, we plan to add a dependency on [chardet](https://pypi.org/project/chardet/) for more robust charset detection and proper encoding conversion.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
