### PR TITLE
fix(resources): log unmapped search engine errors

### DIFF
--- a/invenio_records_resources/resources/errors.py
+++ b/invenio_records_resources/resources/errors.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2020-2026 CERN.
 # SPDX-FileCopyrightText: 2020 Northwestern University
 # SPDX-FileCopyrightText: 2023 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 Paradigm Repositories.
 # SPDX-License-Identifier: MIT
 
 """Common Errors handling for Resources."""
@@ -8,7 +9,7 @@
 from json import JSONDecodeError
 
 import marshmallow as ma
-from flask import jsonify, make_response, request, url_for
+from flask import current_app, jsonify, make_response, request, url_for
 from flask_resources import HTTPJSONException, create_error_handler
 from invenio_i18n import lazy_gettext as _
 from invenio_pidstore.errors import (
@@ -73,13 +74,27 @@ class HTTPJSONSearchRequestError(HTTPJSONException):
 
     def __init__(self, error):
         """Parse RequestError."""
-        cause_types = {c["type"] for c in error.info["error"]["root_cause"]}
+        error_info = error.info if isinstance(error.info, dict) else {}
+        root_causes = (error_info.get("error") or {}).get("root_cause") or []
+        cause_types = {c["type"] for c in root_causes}
+
         for t in cause_types:
             if t in self.causes_responses:
                 code, msg = self.causes_responses[t]
                 super().__init__(code=code, description=msg)
                 return
-        super().__init__(code=500, description=_("Internal server error"))
+
+        # Unmapped search engine error: log the full cause (visible in logs
+        # and error tracking) and expose only the cause types to the client.
+        current_app.logger.exception(
+            "Unhandled search engine RequestError: %s",
+            root_causes or str(error),
+        )
+        super().__init__(
+            code=500,
+            description=_("Internal server error"),
+            errors=[{"type": t} for t in sorted(cause_types)] or None,
+        )
 
 
 def create_pid_redirected_error_handler():

--- a/tests/resources/test_errors.py
+++ b/tests/resources/test_errors.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 Paradigm Repositories.
+# SPDX-License-Identifier: MIT
+
+"""Resource error handling tests."""
+
+import pytest
+from invenio_search.engine import search
+
+from invenio_records_resources.resources.errors import HTTPJSONSearchRequestError
+
+
+def _request_error(info):
+    """Create a search engine RequestError with the given error info."""
+    return search.exceptions.RequestError(400, "search_error", info)
+
+
+def _log_records(caplog):
+    return [
+        r
+        for r in caplog.records
+        if "Unhandled search engine RequestError" in r.getMessage()
+    ]
+
+
+def test_mapped_cause_is_not_logged(base_app, caplog):
+    """A mapped root cause keeps its response and stays silent."""
+    error = _request_error(
+        {
+            "error": {
+                "root_cause": [
+                    {"type": "query_parsing_exception", "reason": "bad query"}
+                ]
+            }
+        }
+    )
+
+    with base_app.app_context():
+        exc = HTTPJSONSearchRequestError(error)
+
+    assert exc.code == 400
+    assert exc.errors is None
+    assert not _log_records(caplog)
+
+
+def test_unmapped_cause_is_logged_and_exposed(base_app, caplog):
+    """An unmapped root cause is logged and its type exposed to the client."""
+    error = _request_error(
+        {
+            "error": {
+                "root_cause": [
+                    {
+                        "type": "mapper_parsing_exception",
+                        "reason": "failed to parse field [foo]",
+                    }
+                ]
+            }
+        }
+    )
+
+    with base_app.app_context():
+        exc = HTTPJSONSearchRequestError(error)
+
+    assert exc.code == 500
+    assert exc.errors == [{"type": "mapper_parsing_exception"}]
+
+    log_records = _log_records(caplog)
+    assert len(log_records) == 1
+    assert "failed to parse field [foo]" in log_records[0].getMessage()
+
+
+@pytest.mark.parametrize(
+    "info",
+    [
+        "not-a-dict",
+        {},
+        {"error": {}},
+        {"error": {"root_cause": []}},
+    ],
+)
+def test_malformed_error_info_does_not_raise(base_app, caplog, info):
+    """Malformed error info still results in a logged generic 500."""
+    error = _request_error(info)
+
+    with base_app.app_context():
+        exc = HTTPJSONSearchRequestError(error)
+
+    assert exc.code == 500
+    assert exc.errors is None
+    assert len(_log_records(caplog)) == 1


### PR DESCRIPTION
### Description

`HTTPJSONSearchRequestError` converts any search engine `RequestError` whose root cause is not in `causes_responses` into a generic `{"status": 500, "message": "Internal server error"}` response. Because the exception is turned into a clean `HTTPException` by the resource error
handler, **nothing is logged and nothing reaches error tracking (e.g. Sentry)** — the failure is completely invisible on the server.

On an instance with a stale `communitymembers` index mapping (after a somewhat failed upgrade), `POST /api/communities` returned a silent `500`. The community was created and indexed, but indexing the owner member document raised a `RequestError` (`strict_dynamic_mapping_exception`) at unit-of-work commit.
The only trace to be found was the uwsgi request line. No traceback in the logs, nothing in Sentry, and a response body with no actionable information. Diagnosing it required replaying the service calls in a shell.

### Changes

* **Log unmapped root causes**: the fallback `500` path now calls `current_app.logger.exception(...)` with the full `root_cause` payload. Since the constructor runs inside the `except RequestError` block of the error handler, the log record carries the original traceback, so the error shows up in logs and in error tracking via the logging integration.
* **Expose sanitised cause types to the client**: the fallback response now includes the root cause *types* (not the `reason` strings, to avoid leaking index/mapping internals) via the existing `errors` field:
```json
  {
    "status": 500,
    "message": "Internal server error",
    "errors": [{"type": "mapper_parsing_exception"}]
  }
```

Mapped causes (`query_shard_exception`, `query_parsing_exception`, `illegal_argument_exception`) behave exactly as before — they are user-input/configuration responses and are not logged.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
