### PR TITLE
fix(files): strip surrounding whitespace from file keys

### DIFF
--- a/invenio_records_resources/services/files/schema.py
+++ b/invenio_records_resources/services/files/schema.py
@@ -9,10 +9,10 @@
 from datetime import timezone
 from typing import Mapping
 
-from marshmallow import RAISE, Schema, ValidationError, post_dump, pre_load
+from marshmallow import RAISE, Schema, ValidationError, post_dump, pre_load, validate
 from marshmallow.fields import UUID, Boolean, Dict, Integer, Nested, Str
 from marshmallow_oneofschema import OneOfSchema
-from marshmallow_utils.fields import GenMethod, Links, TZDateTime
+from marshmallow_utils.fields import GenMethod, Links, SanitizedUnicode, TZDateTime
 
 from ...proxies import current_transfer_registry
 
@@ -146,7 +146,9 @@ class InitFileSchemaMixin(Schema):
 
         unknown = RAISE
 
-    key = Str(required=True, dump_only=False)
+    key = SanitizedUnicode(
+        required=True, validate=validate.Length(min=1), dump_only=False
+    )
     storage_class = Str(dump_default="L", dump_only=False)
     checksum = Str(dump_only=False)
     size = Integer(dump_only=False)

--- a/tests/services/files/test_file_service.py
+++ b/tests/services/files/test_file_service.py
@@ -11,7 +11,7 @@ import pytest
 from flask_principal import Identity
 from invenio_access import any_user
 from invenio_access.permissions import system_identity
-from invenio_files_rest.errors import FileSizeError
+from invenio_files_rest.errors import FileSizeError, InvalidKeyError
 from marshmallow import ValidationError
 
 from invenio_records_resources.services.errors import (
@@ -190,6 +190,55 @@ def test_init_files(file_service, location, example_file_record, identity_simple
     assert file_to_initialise[1]["key"] == second_entry["key"]
     assert file_to_initialise[1]["metadata"] == second_entry["metadata"]
     assert second_entry["access"]["hidden"] is True
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("article.txt ", "article.txt"),
+        (" article.txt", "article.txt"),
+        ("  article.txt  ", "article.txt"),
+        ("my article.txt", "my article.txt"),
+    ],
+)
+def test_init_files_strips_surrounding_whitespace_from_key(
+    file_service, location, example_file_record, identity_simple, key, expected
+):
+    """Surrounding whitespace in a file key is stripped, inner whitespace is kept.
+
+    A key with a trailing space breaks extension detection, which in turn makes
+    the file fall back to the ``application/octet-stream`` mimetype.
+    """
+    recid = example_file_record["id"]
+
+    result = file_service.init_files(identity_simple, recid, [{"key": key}])
+
+    assert result.to_dict()["entries"][0]["key"] == expected
+
+
+@pytest.mark.parametrize("key", ["", " ", "   "])
+def test_init_files_rejects_blank_key(
+    file_service, location, example_file_record, identity_simple, key
+):
+    """A key that is empty once stripped is rejected rather than stored."""
+    recid = example_file_record["id"]
+
+    with pytest.raises(ValidationError) as e:
+        file_service.init_files(identity_simple, recid, [{"key": key}])
+
+    assert "key" in e.value.normalized_messages()[0]
+
+
+def test_init_files_key_collision_after_stripping(
+    file_service, location, example_file_record, identity_simple
+):
+    """Keys that only differ by surrounding whitespace collide after stripping."""
+    recid = example_file_record["id"]
+
+    with pytest.raises(InvalidKeyError):
+        file_service.init_files(
+            identity_simple, recid, [{"key": "article.txt"}, {"key": "article.txt "}]
+        )
 
 
 def test_retrieve_non_existing_file(


### PR DESCRIPTION

:heart: Thank you for your contribution!

### Description

Fixes CERNDocumentServer/cds-rdm#674

When a file is uploaded with a space at the start or the end of its name, that
space is kept as part of the file key. This breaks the file type check. The type
is worked out from the text after the last dot, so a space at the end makes the
ending "jpg " instead of "jpg". That is not a known type, so the file is treated
as application/octet-stream. The result is that images do not show a preview and
look like plain downloads instead.

This change uses SanitizedUnicode for the file key, which removes spaces at the
start and the end. invenio-rdm-records already uses SanitizedUnicode for the same
field in its own file schema, so this makes the two agree.

It also adds a minimum length check. Taking the spaces off a key like "  " leaves
an empty string, and without this check a file with an empty key would be created.
Spaces inside a name are still kept, so a file called "my report.pdf" is not
affected.

Two notes:

- Keys that were different before can now clash, for example "a.txt" and "a.txt ".
  The existing check in the files manager already returns a clear error for this,
  so no new code was needed, but I added a test so it cannot turn into one file
  overwriting another later on.

- This only fixes new uploads. Records that are already saved keep their old keys,
  so those would need a separate clean-up. Happy to look at that separately if it is needed. 



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**
N/A (no frontend changes)

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


